### PR TITLE
map glutSpecialFunc to ViewerWidget::special instead of key

### DIFF
--- a/owl/common/viewerWidget/GlutWindow.cpp
+++ b/owl/common/viewerWidget/GlutWindow.cpp
@@ -92,7 +92,7 @@ namespace owl {
       }
       virtual void special(int key, const vec2i &where)
       {
-        if (widget) widget->key(key,where);
+        if (widget) widget->special(key,where);
       }
       
       /*! resize window */


### PR DESCRIPTION
the docs say so - and it was frustrating to quit an application
every time when trying to trigger a screenshot with Shift_Right-!