### PR TITLE
Use cuda/gl interop to copy image to FB on the device for optix7course

### DIFF
--- a/samples/advanced/optix7course/SampleRenderer.cpp
+++ b/samples/advanced/optix7course/SampleRenderer.cpp
@@ -222,7 +222,7 @@ namespace osc {
       geoms.push_back(geom);
     }
 
-#if 0
+#if 1
     OWLGroup triGroup = owlTrianglesGeomGroupCreate(context,geoms.size(),geoms.data());
     owlGroupBuildAccel(triGroup);
 
@@ -314,5 +314,19 @@ namespace osc {
     // samples let's just do it this way:
     memcpy(h_pixels,owlBufferGetPointer(fbFinal,0),fbSize.x*fbSize.y*sizeof(int));
   }
-  
+
+  void SampleRenderer::copyGPUPixels(cudaGraphicsResource_t &texture)
+  {
+    cudaArray_t array;
+    cudaGraphicsSubResourceGetMappedArray(&array, texture, 0, 0);
+    cudaMemcpy2DToArray(array,
+        0,
+        0,
+        reinterpret_cast<const void *>(owlBufferGetPointer(fbFinal, 0)),
+        fbSize.x * sizeof(uint32_t),
+        fbSize.x * sizeof(uint32_t),
+        fbSize.y,
+        cudaMemcpyDeviceToDevice);
+  }
+
 } // ::osc

--- a/samples/advanced/optix7course/SampleRenderer.h
+++ b/samples/advanced/optix7course/SampleRenderer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <owl/owl.h>
+#include <cuda_gl_interop.h>
 // our own classes, partly shared between host and device
 #include "CUDABuffer.h"
 #include "LaunchParams.h"
@@ -56,6 +57,11 @@ namespace osc {
 
     /*! download the rendered color buffer */
     void downloadPixels(uint32_t h_pixels[]);
+
+    /*! copy the pixels to the mapped GPU texture from GL.
+     * The resource should be mapped prior to calling this method.
+     * The texture should be RGBA8 format */
+    void copyGPUPixels(cudaGraphicsResource_t &texture);
 
     /*! set camera to render with */
     void setCamera(const Camera &camera);


### PR DESCRIPTION
This adds use of a OpenGL-CUDA interop texture to do a device-side copy of the rendered image to the texture used to display the rendering.

I also toggled the `#if` on line 255 of `SampleRenderer.cpp` in the course to place the triangle geometry in a dummy instance to fix the scene setup w/ OWL so it's renderable