### PR TITLE
Make TBB optional, even though it might be available on the system.…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ project(Optix-OWL VERSION 0.7.4)
 
 OPTION(OWL_BUILD_SAMPLES "Build the Samples?" OFF)
 OPTION(OWL_BUILD_ADVANCED_TESTS "Build the *advanced* test-cases?" OFF)
+OPTION(OWL_USE_TBB "Use TBB to parallelize computation?" ON)
 
 cmake_minimum_required(VERSION 2.8)
 # iw, 1/3/20: yes, i know this is 'old' cmake style, but on CentOS7

--- a/owl/CMakeLists.txt
+++ b/owl/CMakeLists.txt
@@ -14,7 +14,11 @@
 # limitations under the License.                                           #
 # ======================================================================== #
 
+if (OWL_USE_TBB)
 include("common/cmake/configure_tbb.cmake")
+else()
+add_definitions(-DOWL_DISABLE_TBB=1)
+endif()
 
 # owl-common library (math stuff, utils, etc; mostly header-only)
 add_subdirectory(common)

--- a/owl/common/cmake/configure_owl.cmake
+++ b/owl/common/cmake/configure_owl.cmake
@@ -20,7 +20,7 @@
 #
 # OWL_LIBRARIES - list of libraries to link against when building owl programs
 
-if (NOT WIN32)
+if (OWL_USE_TBB)
   include(configure_tbb)
 endif()
 

--- a/owl/common/parallel/parallel_for.h
+++ b/owl/common/parallel/parallel_for.h
@@ -21,10 +21,12 @@
 #include <mutex>
 // tbb
 #if OWL_HAVE_TBB
+#ifndef OWL_DISABLE_TBB
 #include <tbb/parallel_for.h>
 #include <tbb/task_arena.h>
 #include <tbb/task_scheduler_init.h>
 #define OWL_HAVE_PARALLEL_FOR 1
+#endif
 #endif
 
 namespace owl {
@@ -58,7 +60,9 @@ namespace owl {
       }
     }
 #else
+#ifndef OWL_DISABLE_TBB
 # pragma message("warning: TBB not available, will replace all parallel_for's with serial_for's")
+#endif
     template<typename INDEX_T, typename TASK_T>
     inline void parallel_for(INDEX_T nTasks, TASK_T&& taskFunction, size_t blockSize=1)
     { serial_for(nTasks,taskFunction); }


### PR DESCRIPTION
These changes should make including OWL in external projects (especially on windows) much easier. 
To disable TBB (either on Windows or Linux), set the OWL_USE_TBB option OFF (it's ON by default).

I'm also assuming that when a dev explicitly disables TBB, that they are aware of any performance tradeoffs, so I'm disabling the performance warning when TBB is explicitly disabled, but keeping the warning when TBB is requested but not found.