### PR TITLE
Add parameter to control window visibility (default == true)

### DIFF
--- a/samples/common/owlViewer/OWLViewer.cpp
+++ b/samples/common/owlViewer/OWLViewer.cpp
@@ -316,7 +316,8 @@ namespace owl {
     }
     
     OWLViewer::OWLViewer(const std::string &title,
-                         const vec2i &initWindowSize)
+                         const vec2i &initWindowSize,
+                               bool visible)
     {
       glfwSetErrorCallback(glfw_error_callback);
       // glfwInitHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
@@ -325,7 +326,7 @@ namespace owl {
       
       glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
       glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-      glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
+      glfwWindowHint(GLFW_VISIBLE, visible);
       
       handle = glfwCreateWindow(initWindowSize.x, initWindowSize.y,
                                 title.c_str(), NULL, NULL);

--- a/samples/common/owlViewer/OWLViewer.h
+++ b/samples/common/owlViewer/OWLViewer.h
@@ -71,7 +71,8 @@ namespace owl {
       static inline vec3f getUpVector(const vec3f &v) { return owl::viewer::getUpVector(v); }
 
       OWLViewer(const std::string &title = "OWL Sample Viewer",
-                const vec2i &initWindowSize=vec2i(1200,800)
+                const vec2i &initWindowSize=vec2i(1200,800),
+                      bool visible=true
                 // ,
                 // const vec3f &cameraInitFrom = vec3f(0,0,-1),
                 // const vec3f &cameraInitAt   = vec3f(0,0,0),


### PR DESCRIPTION
Simple tweak to allow use of GLFW machinery without actually displaying the window (e.g., for command line applications)