### PR TITLE
Fixed a typo and added non-env OptiX_INSTALL_DIR in FindOptiX.cmake

### DIFF
--- a/owl/cmake/FindOptiX.cmake
+++ b/owl/cmake/FindOptiX.cmake
@@ -29,14 +29,16 @@
 # Locate the OptiX distribution.  Search relative to the SDK first, then look in the system.
 
 # Our initial guess will be within the SDK.
-if (WIN32)
-  if ($ENV{OptiX_INSTALL_DIR})
-  set(OptiX_INSTALL_DIR $ENV{OptiX_INSTALL_DIR})
+if (NOT DEFINED OptiX_INSTALL_DIR)
+  if (WIN32)
+    if ($ENV{OptiX_INSTALL_DIR})
+    set(OptiX_INSTALL_DIR $ENV{OptiX_INSTALL_DIR})
+    else()
+    set(OptiX_INSTALL_DIR "c:/ProgramData/NVIDIA Corporation/OptiX SDK 7.2.0")
+    endif()
   else()
-  set(OptiX_INSTALL_DIR "c:/ProgramData/NVIDIA Corporation/OptiX SDK 7.1.0")
+    set(OptiX_INSTALL_DIR $ENV{OptiX_INSTALL_DIR})
   endif()
-else()
-  set(OptiX_INSTALL_DIR $ENV{OptiX_INSTALL_DIR})
 endif()
 #set(OptiX_INSTALL_DIR "${CMAKE_SOURCE_DIR}/../" CACHE PATH "Path to OptiX installed location.")
 
@@ -154,7 +156,7 @@ macro(OptiX_check_same_path libA libB)
       # to the ${libB}.
       get_filename_component(_optix_name_of_${libA} "${${libA}_LIBRARY}" NAME)
       if(EXISTS "${_optix_path_to_${libB}}/${_optix_name_of_${libA}}")
-        message(WARNING " ${libA} library found next to ${libB} library that is not being used.  Due to the way we are using rpath, the copy of ${libA} next to ${libB} will be used during loading instead of the one you intended.  Consider putting the libraries in the same directory or moving ${_optix_path_to_${libB}}/${_optix_name_of_${libA} out of the way.")
+        message(WARNING " ${libA} library found next to ${libB} library that is not being used.  Due to the way we are using rpath, the copy of ${libA} next to ${libB} will be used during loading instead of the one you intended.  Consider putting the libraries in the same directory or moving ${_optix_path_to_${libB}}/${_optix_name_of_${libA}} out of the way.")
       endif()
     endif()
     set( _${libA}_rpath "-Wl,-rpath,${_optix_path_to_${libA}}" )
@@ -177,4 +179,3 @@ if(APPLE)
   set( optix_rpath ${_optix_rpath} ${_optixu_rpath} ${_optix_prime_rpath} )
   list(REMOVE_DUPLICATES optix_rpath)
 endif()
-


### PR DESCRIPTION
- Fix a typo in a warning message. Should have no runtime effect, but causes syntax highlighting for the rest of the file to be messed up as one of the variable substitutions has no closing brace.
- Added check for non-env `OptiX_INSTALL_DIR` already being set (e.g. by surrounding project). ViSII currently has its own nearly duplicated FindOptiX.cmake for the sole purpose of circumventing the restriction that `OptiX_INSTALL_DIR` can't be specified to OWL. Accepting this change would allow ViSII to get rid of this file, and ease integration in other third-party projects.
- Changed the default Windows OptiX SDK version to 7.2.0 from 7.1.0.