### PR TITLE
Fixed OptiX install dir environment variable check on Windows

### DIFF
--- a/owl/cmake/FindOptiX.cmake
+++ b/owl/cmake/FindOptiX.cmake
@@ -30,7 +30,7 @@
 
 # Our initial guess will be within the SDK.
 if (WIN32)
-  if ($ENV{OptiX_INSTALL_DIR})
+  if (EXISTS "$ENV{OptiX_INSTALL_DIR}")
   set(OptiX_INSTALL_DIR $ENV{OptiX_INSTALL_DIR})
   else()
   set(OptiX_INSTALL_DIR "c:/ProgramData/NVIDIA Corporation/OptiX SDK 7.1.0")


### PR DESCRIPTION
Fixed a CMake syntax issue--the existing version evaluates to `FALSE` regardless of whether the environment variable is set or is set to a non-empty string, leading to a fallback to the hardcoded path and fail to configure. Adding the quotes or removing the dollar sign doesn't solve the problem, but checking if the directory exists does.