### PR TITLE
Expose visibility masks on instance groups and rays

### DIFF
--- a/owl/InstanceGroup.cpp
+++ b/owl/InstanceGroup.cpp
@@ -98,7 +98,15 @@ namespace owl {
   /* set instance IDs to use for the children - MUST be an array of children.size() items */
   void InstanceGroup::setInstanceIDs(const uint32_t *_instanceIDs)
   {
+    instanceIDs.resize(children.size());
     std::copy(_instanceIDs,_instanceIDs+instanceIDs.size(),instanceIDs.data());
+  }
+
+  /* set visibility masks to use for the children - MUST be an array of children.size() items */
+  void InstanceGroup::setVisibilityMasks(const uint8_t *_visibilityMasks)
+  {
+    visibilityMasks.resize(children.size());
+    std::copy(_visibilityMasks,_visibilityMasks+visibilityMasks.size(),visibilityMasks.data());
   }
   
   void InstanceGroup::setChild(size_t childID, Group::SP child)
@@ -190,9 +198,8 @@ namespace owl {
         
       oi.flags             = OPTIX_INSTANCE_FLAG_NONE;
       oi.instanceId        = (instanceIDs.empty())?uint32_t(childID):instanceIDs[childID];
-      oi.visibilityMask    = 255;
+      oi.visibilityMask    = (visibilityMasks.empty()) ? 255 : visibilityMasks[childID];
       oi.sbtOffset         = context->numRayTypes * child->getSBTOffset();
-      oi.visibilityMask    = 255;
       oi.traversableHandle = child->getTraversable(device);
       assert(oi.traversableHandle);
       
@@ -420,7 +427,7 @@ namespace owl {
       oi.flags             = OPTIX_INSTANCE_FLAG_NONE;
       oi.instanceId        = (instanceIDs.empty())?uint32_t(childID):instanceIDs[childID];
       oi.sbtOffset         = context->numRayTypes * child->getSBTOffset();
-      oi.visibilityMask    = 1; //255;
+      oi.visibilityMask    = (visibilityMasks.empty()) ? 255 : visibilityMasks[childID];
       oi.traversableHandle = childMotionHandle; 
       optixInstances[childID] = oi;
     }

--- a/owl/InstanceGroup.h
+++ b/owl/InstanceGroup.h
@@ -62,6 +62,10 @@ namespace owl {
     /* set instance IDs to use for the children - MUST be an array of
        children.size() items */
     void setInstanceIDs(const uint32_t *instanceIDs);
+
+    /* set visibility masks to use for the children - MUST be an array of
+       children.size() items */
+    void setVisibilityMasks(const uint8_t *visibilityMasks);
       
     void buildAccel() override;
     void refitAccel() override;
@@ -94,6 +98,12 @@ namespace owl {
       specified we/optix will fill in automatically using
       instanceID=childID */
     std::vector<uint32_t>   instanceIDs;
+
+    /*! vector of visibility masks to use for these instances - if not
+      specified we/optix will fill in automatically using
+      visibility=255 */
+    std::vector<uint8_t> visibilityMasks;
+
   };
 
   // ------------------------------------------------------------------

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -1394,9 +1394,6 @@ namespace owl {
     group->setTransforms(timeStep,floatsForThisStimeStep,matrixFormat);
   }
   
-  /*! this function allows to set up to N different arrays of trnsforms
-    for motion blur; the first such array is used as transforms for
-    t=0, the last one for t=1.  */
   OWL_API void
   owlInstanceGroupSetInstanceIDs(OWLGroup _group,
                                  const uint32_t *instanceIDs)
@@ -1408,6 +1405,19 @@ namespace owl {
     assert(group);
 
     group->setInstanceIDs(instanceIDs);
+  }
+
+  OWL_API void
+  owlInstanceGroupSetVisibilityMasks(OWLGroup _group,
+                                     const uint8_t *visibilityMasks)
+  {
+    LOG_API_CALL();
+
+    assert(_group);
+    InstanceGroup::SP group = ((APIHandle*)_group)->get<InstanceGroup>();
+    assert(group);
+
+    group->setVisibilityMasks(visibilityMasks);
   }
   
   OWL_API void

--- a/owl/include/owl/owl_device.h
+++ b/owl/include/owl/owl_device.h
@@ -134,15 +134,18 @@ namespace owl {
     inline __device__ RayT(const vec3f &origin,
                           const vec3f &direction,
                           float tmin,
-                          float tmax)
+                          float tmax,
+                          OptixVisibilityMask visibilityMask=(OptixVisibilityMask)(-1))
       : origin(origin),
         direction(direction),
         tmin(tmin),
-        tmax(tmax)
+        tmax(tmax),
+        visibilityMask(visibilityMask)
     {}
     
     vec3f origin, direction;
     float tmin=0.f,tmax=1e30f,time=0.f;
+    OptixVisibilityMask visibilityMask=(OptixVisibilityMask)-1;
   };
   typedef RayT<0,1> Ray;
 
@@ -164,7 +167,7 @@ namespace owl {
                ray.tmin,
                ray.tmax,
                ray.time,
-               (OptixVisibilityMask)-1,
+               ray.visibilityMask,
                /*rayFlags     */rayFlags,
                /*SBToffset    */ray.rayType,
                /*SBTstride    */ray.numRayTypes,
@@ -191,7 +194,7 @@ namespace owl {
                ray.tmin,
                ray.tmax,
                ray.time,
-               (OptixVisibilityMask)-1,
+               ray.visibilityMask,
                /*rayFlags     */0u,
                /*SBToffset    */ray.rayType + numRayTypes*sbtOffset,
                /*SBTstride    */numRayTypes,

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -756,6 +756,11 @@ owlInstanceGroupSetInstanceIDs(OWLGroup group,
                                const uint32_t *instanceIDs);
 
 OWL_API void
+owlInstanceGroupSetVisibilityMasks(OWLGroup group,
+                               const uint8_t *visibilityMasks);
+
+
+OWL_API void
 owlGeomTypeSetClosestHit(OWLGeomType type,
                          int rayType,
                          OWLModule module,


### PR DESCRIPTION
This exposes OptiX visibility masks on OWL instance groups and ray types.  An instance is visible to a ray if the two masks when ANDed together are not 0.  Tested this in sample code not shown here.

Also fixed a bug with setting instance ids.