### PR TITLE
match internal optix symbol in ptx generated by OptiX 7.3

### DIFF
--- a/owl/Module.cpp
+++ b/owl/Module.cpp
@@ -59,7 +59,9 @@ namespace owl {
 
     for (const char *s = orignalPtxCode; *s; ) {
       std::string line = getNextLine(s);
-      if (line.find(" _optix_") != line.npos)
+      if (line.find(" _optix_") != line.npos ||
+          line.find(",_optix_") != line.npos
+          )
         fixed << "//dropped: " << line;
       else
         fixed << line;


### PR DESCRIPTION
Small fix for when OWL does this pass where it hides OptiX symbols.  The PTX for OptiX 7.3 contains a new pattern: "call(...),_optix_trace_...".  Note the absence of any leading space before "_optix".

Could do a regex here or something else, but this was enough to fix a few samples that I tried.