### PR TITLE
Fix pthread linker issues with cmake 3.20.2

### DIFF
--- a/owl/CMakeLists.txt
+++ b/owl/CMakeLists.txt
@@ -172,6 +172,7 @@ cuda_add_library(owl_static
 target_link_libraries(owl_static
    ${CUDA_LIBRARIES}
    ${CUDA_CUDA_LIBRARY}
+   ${CMAKE_THREAD_LIBS_INIT}
   )
 
 


### PR DESCRIPTION
This fixes https://github.com/owl-project/owl/issues/91