### PR TITLE
new API function to set number of attributes for custom IS program

### DIFF
--- a/owl/Context.cpp
+++ b/owl/Context.cpp
@@ -583,6 +583,15 @@ namespace owl {
     motionBlurEnabled = true;
   }
 
+  void Context::setNumAttributeValues(size_t numAttributeValues)
+  {
+    for (auto device : getDevices()) {
+      assert("check programs have not been built"
+             && device->allActivePrograms.empty());
+    }
+    this->numAttributeValues = (int)numAttributeValues;
+  }
+
   void Context::buildPrograms(bool debug)
   {
     buildModules(debug);

--- a/owl/Context.h
+++ b/owl/Context.h
@@ -95,6 +95,10 @@ namespace owl {
       instances) */
     void setMaxInstancingDepth(int32_t maxInstanceDepth);
 
+    /* Set number of attributes for passing data from custom Intersection programs
+       to ClosestHit programs.  Default 2.  Has no effect once programs are built.*/
+    void setNumAttributeValues(size_t numAttributeValues);
+
 
     // ------------------------------------------------------------------
     // internal mechanichs/plumbling that do the actual work
@@ -272,6 +276,9 @@ namespace owl {
     /*! by default motion blur is off, as it costs performacne - set
       via enableMotimBlur() */
     bool motionBlurEnabled = false;
+
+    /* Number of attributes for writing data between Intersection and ClosestHit */
+    int numAttributeValues = 2;
 
     /*! a set of dummy (ie, empty) launch params. allows us for always
       using the same launch code, *with* launch params, even if th

--- a/owl/DeviceContext.cpp
+++ b/owl/DeviceContext.cpp
@@ -298,7 +298,7 @@ namespace owl {
     }
     pipelineCompileOptions.usesMotionBlur     = parent->motionBlurEnabled;
     pipelineCompileOptions.numPayloadValues   = 2;
-    pipelineCompileOptions.numAttributeValues = 2;
+    pipelineCompileOptions.numAttributeValues = parent->numAttributeValues;
     pipelineCompileOptions.exceptionFlags     = OPTIX_EXCEPTION_FLAG_NONE;
     pipelineCompileOptions.pipelineLaunchParamsVariableName = "optixLaunchParams";
     

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -95,6 +95,13 @@ using namespace owl;
   }
 
   OWL_API void
+  owlContextSetNumAttributeValues(OWLContext _context, size_t numAttributeValues)
+  {
+    LOG_API_CALL();
+    checkGet(_context)->setNumAttributeValues(numAttributeValues);
+  }
+
+  OWL_API void
   owlContextSetBoundLaunchParamValues(OWLContext _context,
                                       const OWLBoundValueDecl *_boundValues,
                                       int numBoundValues)
@@ -145,7 +152,7 @@ using namespace owl;
     LOG_API_CALL();
     checkGet(_context)->setMaxInstancingDepth(maxInstanceDepth);
   }
-  
+
 
   OWL_API void
   owlEnableMotionBlur(OWLContext _context)

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -380,6 +380,12 @@ OWL_API void
 owlContextSetRayTypeCount(OWLContext context,
                           size_t numRayTypes);
 
+/* Set number of attributes for passing data from custom Intersection programs
+   to ClosestHit programs.  Default 2.  Has no effect once programs are built.*/
+OWL_API void
+owlContextSetNumAttributeValues(OWLContext context,
+                                size_t numAttributeValues);
+
 /*! tells OptiX to specialize the values of certain launch parameters
   when compiling modules, and ignore their values at launch.
   See section 6.3.1 of the OptiX 7.2 programming guide.
@@ -416,7 +422,7 @@ owlContextSetBoundLaunchParamValues(OWLContext context,
 OWL_API void
 owlSetMaxInstancingDepth(OWLContext context,
                          int32_t maxInstanceDepth);
-  
+
 
 OWL_API void
 owlContextDestroy(OWLContext context);

--- a/samples/advanced/rtgems2-voxrender/hostCode.cpp
+++ b/samples/advanced/rtgems2-voxrender/hostCode.cpp
@@ -1120,6 +1120,8 @@ Viewer::Viewer(const ogt_vox_scene *scene, SceneType sceneType, const GlobalOpti
 
   owlContextSetRayTypeCount(context, 3);  // primary, shadow, toon outline
 
+  owlContextSetNumAttributeValues(context, 2);
+
   // Launch params
   OWLVarDecl launchVars[] = {
 


### PR DESCRIPTION
Doesn't have to be called, and default is still 2.  I added a call to this function in the voxrender sample as a test, although it coincidentally needs 2 as well.