### PR TITLE
Replace throw calls with OWL_RAISE macro

### DIFF
--- a/owl/APIHandle.h
+++ b/owl/APIHandle.h
@@ -62,10 +62,10 @@ namespace owl {
       const std::string objectTypeID = typeid(*object.get()).name();
 	
       const std::string tTypeID = typeid(T).name();
-      throw std::runtime_error("could not convert APIHandle of type "
-                               + objectTypeID
-                               + " to object of type "
-                               + tTypeID);
+      OWL_RAISE("could not convert APIHandle of type "
+                + objectTypeID
+                + " to object of type "
+                + tTypeID);
     }
     assert(asT);
     return asT;

--- a/owl/Buffer.cpp
+++ b/owl/Buffer.cpp
@@ -113,7 +113,7 @@ namespace owl {
     if (type == OWL_TEXTURE)
       return std::make_shared<DeviceBuffer::DeviceDataForTextures>(this,device);
 
-    throw std::runtime_error("unsupported element type for device buffer");
+    OWL_RAISE("unsupported element type for device buffer");
   }
   
   void DeviceBuffer::upload(const void *hostPtr, size_t offset, int64_t count)
@@ -335,8 +335,8 @@ namespace owl {
   
   void HostPinnedBuffer::upload(const int deviceID, const void *hostPtr, size_t offset, int64_t count)
   {
-    throw std::runtime_error("uploading to specific device doesn't "
-                             "make sense for host pinned buffers");
+    OWL_RAISE("uploading to specific device doesn't "
+              "make sense for host pinned buffers");
   }
   
   // ------------------------------------------------------------------
@@ -412,8 +412,8 @@ namespace owl {
   void ManagedMemoryBuffer::upload(const int deviceID,
                                    const void *hostPtr, size_t offset, int64_t count)
   {
-    throw std::runtime_error("copying to a specific device doesn't"
-                             " make sense for a managed mem buffer");
+    OWL_RAISE("copying to a specific device doesn't"
+              " make sense for a managed mem buffer");
   }
 
   // ------------------------------------------------------------------
@@ -439,12 +439,12 @@ namespace owl {
 
   void GraphicsBuffer::upload(const void *hostPtr, size_t offset, int64_t count)
   {
-    throw std::runtime_error("Buffer::upload doesn' tmake sense for graphics buffers");
+    OWL_RAISE("Buffer::upload doesn' tmake sense for graphics buffers");
   }
   
   void GraphicsBuffer::upload(const int deviceID, const void *hostPtr, size_t offset, int64_t count) 
   {
-    throw std::runtime_error("Buffer::upload doesn' tmake sense for graphics buffers");
+    OWL_RAISE("Buffer::upload doesn' tmake sense for graphics buffers");
   }
   
   void GraphicsBuffer::map(const int deviceID, CUstream stream)

--- a/owl/Context.cpp
+++ b/owl/Context.cpp
@@ -97,8 +97,8 @@ namespace owl {
           int canAccessPeer = 0;
           cudaError_t rc = cudaDeviceCanAccessPeer(&canAccessPeer, cuda_i,cuda_j);
           if (rc != cudaSuccess)
-            throw std::runtime_error("cuda error in cudaDeviceCanAccessPeer: "
-                                     +std::to_string(rc));
+            OWL_RAISE("cuda error in cudaDeviceCanAccessPeer: "
+                      +std::to_string(rc));
           if (!canAccessPeer) {
             // huh. this can happen if you have differnt device
             // types (in my case, a 2070 and a rtx 8000).
@@ -110,8 +110,8 @@ namespace owl {
           
           rc = cudaDeviceEnablePeerAccess(cuda_j,0);
           if (rc != cudaSuccess)
-            throw std::runtime_error("cuda error in cudaDeviceEnablePeerAccess: "
-                                     +std::to_string(rc));
+            OWL_RAISE("cuda error in cudaDeviceEnablePeerAccess: "
+                      +std::to_string(rc));
           ss << " +";
         }
       }
@@ -566,7 +566,7 @@ namespace owl {
     this->maxInstancingDepth = maxInstanceDepth;
     
     if (maxInstancingDepth < 1)
-      throw std::runtime_error
+      OWL_RAISE
         ("a instancing depth of < 1 isnt' currently supported in OWL; "
          "please see comments on owlSetMaxInstancingDepth() (owl/owl_host.h)");
     

--- a/owl/DeviceContext.cpp
+++ b/owl/DeviceContext.cpp
@@ -117,7 +117,7 @@ namespace owl {
     int totalNumDevicesAvailable = 0;
     CUDA_CALL(GetDeviceCount(&totalNumDevicesAvailable));
     if (totalNumDevicesAvailable == 0)
-      throw std::runtime_error("#owl: no CUDA capable devices found!");
+      OWL_RAISE("#owl: no CUDA capable devices found!");
     LOG_OK("found " << totalNumDevicesAvailable << " CUDA device(s)");
 
 
@@ -182,7 +182,7 @@ namespace owl {
     // one device...
     // ------------------------------------------------------------------
     if (devices.empty())
-      throw std::runtime_error("fatal error - could not find/create any optix devices");
+      OWL_RAISE("fatal error - could not find/create any optix devices");
     
     LOG_OK("successfully created device group with " << devices.size() << " devices");
     return devices;
@@ -206,7 +206,7 @@ namespace owl {
     
     CUresult  cuRes = cuCtxGetCurrent(&cudaContext);
     if (cuRes != CUDA_SUCCESS) 
-      throw std::runtime_error("Error querying current CUDA context...");
+      OWL_RAISE("Error querying current CUDA context...");
     
     OPTIX_CHECK(optixDeviceContextCreate(cudaContext, 0, &optixContext));
     OPTIX_CHECK(optixDeviceContextSetLogCallback
@@ -316,7 +316,7 @@ namespace owl {
     
     auto &allPGs = allActivePrograms;
     if (allPGs.empty())
-      throw std::runtime_error("trying to create a pipeline w/ 0 programs!?");
+      OWL_RAISE("trying to create a pipeline w/ 0 programs!?");
     
     char log[2048];
     size_t sizeof_log = sizeof( log );
@@ -337,7 +337,7 @@ namespace owl {
        &maxAllowedByOptix,
        sizeof(maxAllowedByOptix));
     if (uint32_t(parent->maxInstancingDepth+1) > maxAllowedByOptix)
-      throw std::runtime_error
+      OWL_RAISE
         ("error when building pipeline: "
          "attempting to set max instancing depth to "
          "value that exceeds OptiX's MAX_TRAVERSABLE_GRAPH_DEPTH limit");

--- a/owl/InstanceGroup.cpp
+++ b/owl/InstanceGroup.cpp
@@ -90,8 +90,8 @@ namespace owl {
              children.size()*sizeof(affine3f));
     } break;
     default:
-      throw std::runtime_error("used matrix format not yet implmeneted for"
-                               " InstanceGroup::setTransforms");
+      OWL_RAISE("used matrix format not yet implmeneted for"
+                " InstanceGroup::setTransforms");
     };
   }
 

--- a/owl/Module.cpp
+++ b/owl/Module.cpp
@@ -153,9 +153,9 @@ namespace owl {
     if (rc != CUDA_SUCCESS) {
       const char *errName = 0;
       cuGetErrorName(rc,&errName);
-      throw std::runtime_error("unknown CUDA error when building module "
-                               "for bounds program kernel"
-                               +std::string(errName));
+      OWL_RAISE("unknown CUDA error when building module "
+                "for bounds program kernel"
+                +std::string(errName));
     }
     LOG_OK("created module #" << parent->ID << " (both optix and cuda)");
   }

--- a/owl/Object.cpp
+++ b/owl/Object.cpp
@@ -134,7 +134,7 @@ namespace owl {
       
     case OWL_BUFFER:
       //      return sizeof();
-      throw "device code for OWL_BUFFER type not yet implemented";
+      OWL_RAISE("device code for OWL_BUFFER type not yet implemented");
     case OWL_BUFFER_POINTER:
       return sizeof(void *);
     case OWL_GROUP:
@@ -142,9 +142,9 @@ namespace owl {
     case OWL_DEVICE:
       return sizeof(int32_t);
     default:
-      throw std::runtime_error(std::string(__PRETTY_FUNCTION__)
-                               +": not yet implemented for type #"
-                               +std::to_string((int)type));
+      OWL_RAISE(std::string(__PRETTY_FUNCTION__)
+                +": not yet implemented for type #"
+                +std::to_string((int)type));
     }
   }
 
@@ -289,9 +289,9 @@ namespace owl {
         return "OWL_USER_TYPE(sz="
           +std::to_string((size_t)type-(size_t)OWL_USER_TYPE_BEGIN)+")";
       else
-        throw std::runtime_error(std::string(__PRETTY_FUNCTION__)
-                                 +": not yet implemented for type #"
-                                 +std::to_string((int)type));
+        OWL_RAISE(std::string(__PRETTY_FUNCTION__)
+                  +": not yet implemented for type #"
+                  +std::to_string((int)type));
     }
   }
 
@@ -312,7 +312,7 @@ namespace owl {
   void Object::createDeviceData(const std::vector<DeviceContext::SP> &devices)
   {
     if (!deviceData.empty())
-      throw std::runtime_error
+      OWL_RAISE
         ("trying to create device data on object "+toString()
          +", but it already exists!?");
     assert(deviceData.empty());

--- a/owl/Texture.cpp
+++ b/owl/Texture.cpp
@@ -29,7 +29,7 @@ namespace owl {
     case OWL_TEXEL_FORMAT_R32F:
       return sizeof(float);
     default:
-      throw std::runtime_error("texel format not implemented");
+      OWL_RAISE("texel format not implemented");
     };
   }
   

--- a/owl/TrianglesGeomGroup.cpp
+++ b/owl/TrianglesGeomGroup.cpp
@@ -126,9 +126,9 @@ namespace owl {
       assert(tris);
       
       if (tris->vertex.buffers.size() != (size_t)numKeys)
-        throw std::runtime_error("invalid combination of meshes with "
-                                 "different motion keys in the same "
-                                 "triangles geom group");
+        OWL_RAISE("invalid combination of meshes with "
+                  "different motion keys in the same "
+                  "triangles geom group");
       TrianglesGeom::DeviceData &trisDD = tris->getDD(device);
       
       CUdeviceptr     *d_vertices    = trisDD.vertexPointers.data();
@@ -168,8 +168,8 @@ namespace owl {
     }
     
     if (sumPrims > maxPrimsPerGAS) 
-      throw std::runtime_error("number of prim in user geom group exceeds "
-                               "OptiX's MAX_PRIMITIVES_PER_GAS limit");
+      OWL_RAISE("number of prim in user geom group exceeds "
+                "OptiX's MAX_PRIMITIVES_PER_GAS limit");
     
     // ==================================================================
     // BLAS setup: buildinputs set up, build the blas

--- a/owl/UserGeom.cu
+++ b/owl/UserGeom.cu
@@ -212,9 +212,9 @@ namespace owl {
     CUstream stream = device->stream;
     UserGeomType::DeviceData &typeDD = getTypeDD(device);
     if (!typeDD.boundsFuncKernel)
-      throw std::runtime_error("bounds kernel set, but not yet compiled - "
-                               "did you forget to call BuildPrograms() before"
-                               " (User)GroupAccelBuild()!?");
+      OWL_RAISE("bounds kernel set, but not yet compiled - "
+                "did you forget to call BuildPrograms() before"
+                " (User)GroupAccelBuild()!?");
         
     CUresult rc
       = cuLaunchKernel(typeDD.boundsFuncKernel,
@@ -224,8 +224,8 @@ namespace owl {
     if (rc) {
       const char *errName = 0;
       cuGetErrorName(rc,&errName);
-      throw std::runtime_error("unknown CUDA error in calling bounds function kernel: "
-                               +std::string(errName));
+      OWL_RAISE("unknown CUDA error in calling bounds function kernel: "
+                +std::string(errName));
     }
     
     tempMem.free();
@@ -281,14 +281,14 @@ namespace owl {
         LOG_OK("found bounds function " << annotatedProgName << " ... perfect!");
         break;
       case CUDA_ERROR_NOT_FOUND:
-        throw std::runtime_error("in "+std::string(__PRETTY_FUNCTION__)
-                                 +": could not find OPTIX_BOUNDS_PROGRAM("
-                                 +boundsProg.progName+")");
+        OWL_RAISE("in "+std::string(__PRETTY_FUNCTION__)
+                  +": could not find OPTIX_BOUNDS_PROGRAM("
+                  +boundsProg.progName+")");
       default:
         const char *errName = 0;
         cuGetErrorName(rc,&errName);
-        throw std::runtime_error("unknown CUDA error when building bounds program kernel"
-                                 +std::string(errName));
+        OWL_RAISE("unknown CUDA error when building bounds program kernel"
+                  +std::string(errName));
       }
     }
   }

--- a/owl/UserGeomGroup.cpp
+++ b/owl/UserGeomGroup.cpp
@@ -118,8 +118,8 @@ namespace owl {
 
       sumPrims += child->primCount;
       if (sumPrims > maxPrimsPerGAS) 
-        throw std::runtime_error("number of prim in user geom group exceeds "
-                                 "OptiX's MAX_PRIMITIVES_PER_GAS limit");
+        OWL_RAISE("number of prim in user geom group exceeds "
+                  "OptiX's MAX_PRIMITIVES_PER_GAS limit");
 
       UserGeom::DeviceData &ugDD = child->getDD(device);
       

--- a/owl/Variable.cpp
+++ b/owl/Variable.cpp
@@ -282,7 +282,7 @@ namespace owl {
     {}
     void set(const Buffer::SP &value) override
     {
-      throw std::runtime_error("cannot _set_ a device index variable; it is purely implicit");
+      OWL_RAISE("cannot _set_ a device index variable; it is purely implicit");
     }
 
     /*! writes the device specific representation of the given type */
@@ -336,7 +336,7 @@ namespace owl {
     void set(const Group::SP &value) override
     {
       if (value && !std::dynamic_pointer_cast<InstanceGroup>(value))
-        throw std::runtime_error("OWL currently supports only instance groups to be passed to traversal; if you do want to trace rays into a single User or Triangle group, please put them into a single 'dummy' instance with jsut this one child and a identity transform");
+        OWL_RAISE("OWL currently supports only instance groups to be passed to traversal; if you do want to trace rays into a single User or Triangle group, please put them into a single 'dummy' instance with jsut this one child and a identity transform");
       this->group = value;
     }
 

--- a/owl/helper/cuda.h
+++ b/owl/helper/cuda.h
@@ -26,7 +26,7 @@
       fprintf(stderr,                                                   \
               "CUDA call (%s) failed with code %d (line %d): %s\n",     \
               #call, rc, __LINE__, cudaGetErrorString(rc));             \
-      throw std::runtime_error("fatal cuda error");                     \
+      OWL_RAISE("fatal cuda error");                                    \
     }                                                                   \
   }
 
@@ -43,7 +43,7 @@
       fprintf(stderr,                                                   \
               "CUDA call (%s) failed with code %d (line %d): %s\n",     \
               #call, rc, __LINE__, cudaGetErrorString(rc));             \
-      throw std::runtime_error("fatal cuda error");                     \
+      OWL_RAISE("fatal cuda error");                                    \
     }                                                                   \
   }
 
@@ -54,7 +54,7 @@
     if (rc != cudaSuccess) {                                    \
       fprintf(stderr, "error (%s: line %d): %s\n",              \
               __FILE__, __LINE__, cudaGetErrorString(rc));      \
-      throw std::runtime_error("fatal cuda error");             \
+      OWL_RAISE("fatal cuda error");                            \
     }                                                           \
   }
 

--- a/owl/helper/cuda.h
+++ b/owl/helper/cuda.h
@@ -84,7 +84,7 @@
       fprintf(stderr,                                                   \
               "CUDA call (%s) failed with code %d (line %d): %s\n",     \
               #call, rc, __LINE__, cudaGetErrorString(rc));             \
-      throw std::runtime_error("fatal cuda error");                     \
+      exit(2);                                                          \
     }                                                                   \
   }
 

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -270,8 +270,8 @@ using namespace owl;
     assert(obj);
 
     if (!obj->hasVariable(varName))
-      throw std::runtime_error("Trying to get reference to variable '"+std::string(varName)+
-                               "' on object that does not have such a variable");
+      OWL_RAISE("Trying to get reference to variable '"+std::string(varName)+
+                "' on object that does not have such a variable");
     
     Variable::SP var = obj->getVariable(varName);
     assert(var);

--- a/owl/include/owl/common/owl-common.h
+++ b/owl/include/owl/common/owl-common.h
@@ -47,6 +47,9 @@
 #endif
 #endif
 
+#if !defined(WIN32)
+#include <signal.h>
+#endif
 
 #if defined(_MSC_VER)
 #  define OWL_DLL_EXPORT __declspec(dllexport)
@@ -108,7 +111,22 @@
 #define MAYBE_UNUSED
 #endif
 
+namespace detail {
+inline void owlRaise_impl(std::string str)
+{
+  fprintf(stderr,"%s\n",str.c_str());
+#ifdef WIN32
+  if (IsDebuggerPresent())
+    DebugBreak();
+  else
+    throw std::runtime_error(MSG);
+#else
+  raise(SIGINT);
+#endif
+}
+}
 
+#define OWL_RAISE(MSG) detail::owlRaise_impl(MSG);
 
 
 #define OWL_NOTIMPLEMENTED throw std::runtime_error(std::string(__PRETTY_FUNCTION__)+" not implemented")


### PR DESCRIPTION
Instead of throwing an exception and causing the runtime to unwind the stack, the `OWL_RAISE` macro will instead interrupt the program execution, thus allowing to obtain a stack trace in a debugger at the point where the error was raised. This macro could be used in places where we would otherwise use `throw std::runtime_error()`.