### PR TITLE
Compile fix

### DIFF
--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -67,9 +67,9 @@
 
 
 
-#define OWL_OFFSETOF(type,member)               \
-  ((char *)(&((struct type *)0)-> member )      \
-   -                                            \
+#define OWL_OFFSETOF(type,member)                       \
+   (uint32_t)((char *)(&((struct type *)0)-> member )   \
+   -                                                    \
    (char *)(((struct type *)0)))
   
   


### PR DESCRIPTION
On macOS, that conversion from `type((char*)-(char*))` to `uint32_t` is narrowing and therefore a compiler error. (I'm actually surprised that doesn't happen on Linux, too, as there I'd have _expected_ the result from pointer arithmetic to be `ptrdiff_t`, hence 64-bit.)