### PR TITLE
Fixes so that the headers can be used with fakeOwl

### DIFF
--- a/owl/include/owl/owl_device.h
+++ b/owl/include/owl/owl_device.h
@@ -225,10 +225,9 @@ namespace owl {
   extern "C" __global__ \
   void __miss__##programName
 
-
-
 /* defines the wrapper stuff to actually launch all the bounds
    programs from the host - todo: move to deviceAPI.h once working */
+#ifndef OPTIX_BOUNDS_PROGRAM
 #define OPTIX_BOUNDS_PROGRAM(progName)                                  \
   /* fwd decl for the kernel func to call */                            \
   inline __device__                                                     \
@@ -257,5 +256,5 @@ namespace owl {
   /* now the actual device code that the user is writing: */            \
   inline __device__ void __boundsFunc__##progName                       \
   /* program args and body supplied by user ... */
-  
+#endif
   


### PR DESCRIPTION
This is a compatibility patch that would allow the headers to be used with [fakeOwl](https://github.com/szellmann/fakeOwl) right away--it'd allow me to simply copy the headers to my project w/o applying any other patches. The change set consists mostly of querying the presence of the `FAKE_OWL_VERSION` macro and conditionally compiling (or not compiling) platform-specific CUDA code in case it was defined. 