### PR TITLE
embed_ptx() function improvements

### DIFF
--- a/owl/cmake/embed_ptx.cmake
+++ b/owl/cmake/embed_ptx.cmake
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.12)
 
 # NOTE(jda) - CMake 3.17 defines CMAKE_CURRENT_FUNCTION_LIST_DIR, but alas can't
 #             use it yet.
-set(EMBED_PTX_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(EMBED_PTX_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
 
 function(embed_ptx)
   set(oneArgs OUTPUT_TARGET)

--- a/owl/cmake/embed_ptx.cmake
+++ b/owl/cmake/embed_ptx.cmake
@@ -1,7 +1,11 @@
 ## Copyright 2021 Jefferson Amstutz
 ## SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
+
+# NOTE(jda) - CMake 3.17 defines CMAKE_CURRENT_FUNCTION_LIST_DIR, but alas can't
+#             use it yet.
+set(EMBED_PTX_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 function(embed_ptx)
   set(oneArgs OUTPUT_TARGET)
@@ -27,12 +31,7 @@ function(embed_ptx)
       )
   endif()
 
-  set(CMAKE_PREFIX_PATH ${CMAKE_MODULE_PATH})
-  find_file(EMBED_PTX_RUN run_bin2c.cmake)
-  mark_as_advanced(EMBED_PTX_RUN)
-  if(NOT EMBED_PTX_RUN)
-    message(FATAL_ERROR "embed_ptx.cmake and run_bin2c.cmake must be on CMAKE_MODULE_PATH\n")
-  endif()
+  set(EMBED_PTX_RUN ${EMBED_PTX_DIR}/run_bin2c.cmake)
 
   ## Create PTX object target ##
 

--- a/owl/cmake/run_bin2c.cmake
+++ b/owl/cmake/run_bin2c.cmake
@@ -11,7 +11,7 @@ foreach(obj ${OBJECTS})
   get_filename_component(obj_dir ${obj} DIRECTORY)
 
   if(obj_ext MATCHES ".ptx")
-    set(args --name ${obj_name} ${obj})
+    set(args --name ${obj_name}_ptx ${obj})
     execute_process(
       COMMAND "${BIN_TO_C_COMMAND}" ${args}
       WORKING_DIRECTORY ${obj_dir}

--- a/owl/cmake/run_bin2c.cmake
+++ b/owl/cmake/run_bin2c.cmake
@@ -7,11 +7,11 @@ unset(file_contents)
 
 foreach(obj ${OBJECTS})
   get_filename_component(obj_ext ${obj} EXT)
-  get_filename_component(obj_name ${obj} NAME_WE)
   get_filename_component(obj_dir ${obj} DIRECTORY)
 
+  list(POP_FRONT SYMBOL_NAMES obj_name)
   if(obj_ext MATCHES ".ptx")
-    set(args --name ${obj_name}_ptx ${obj})
+    set(args --name ${obj_name} ${obj})
     execute_process(
       COMMAND "${BIN_TO_C_COMMAND}" ${args}
       WORKING_DIRECTORY ${obj_dir}

--- a/samples/advanced/optix7course/SampleRenderer.cpp
+++ b/samples/advanced/optix7course/SampleRenderer.cpp
@@ -22,7 +22,7 @@
 /*! \namespace osc - Optix Siggraph Course */
 namespace osc {
 
-  extern "C" char devicePrograms[];
+  extern "C" char devicePrograms_ptx[];
 
   /*! constructor - performs all setup, including initializing
     optix, creates module, pipeline, programs, SBT, etc. */
@@ -33,7 +33,7 @@ namespace osc {
     context = owlContextCreate(nullptr,1);
     owlContextSetRayTypeCount(context,2);
 
-    module = owlModuleCreate(context,devicePrograms);
+    module = owlModuleCreate(context,devicePrograms_ptx);
     rayGen
       = owlRayGenCreate(context,module,"renderFrame",
                         /* no sbt data: */0,nullptr,-1);

--- a/samples/advanced/rtgems2-voxrender/hostCode.cpp
+++ b/samples/advanced/rtgems2-voxrender/hostCode.cpp
@@ -44,7 +44,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 // Small default vox file as byte buffer
 extern "C" const uint8_t voxBuffer[];
@@ -1113,7 +1113,7 @@ Viewer::Viewer(const ogt_vox_scene *scene, SceneType sceneType, const GlobalOpti
 {
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // Set context options that affect program compilation
   // IMPORTANT: this needs to happen before any calls to owlBuildPrograms() !

--- a/samples/cmdline/s00-rayGenOnly/hostCode.cpp
+++ b/samples/cmdline/s00-rayGenOnly/hostCode.cpp
@@ -35,7 +35,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 // When run, this program produces this PNG as output.
 // In this case the correct result is a red and light gray checkerboard,
@@ -71,7 +71,7 @@ int main(int ac, char **av)
   // This PTX intermediate code representation is then compiled into an OptiX module.
   // See https://devblogs.nvidia.com/how-to-get-started-with-optix-7/ for more information.
   OWLModule module
-    = owlModuleCreate(owl,deviceCode);
+    = owlModuleCreate(owl,deviceCode_ptx);
 
   OWLVarDecl rayGenVars[]
     = {

--- a/samples/cmdline/s01-simpleTriangles/hostCode.cpp
+++ b/samples/cmdline/s01-simpleTriangles/hostCode.cpp
@@ -34,7 +34,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const int NUM_VERTICES = 8;
 vec3f vertices[NUM_VERTICES] =
@@ -73,7 +73,7 @@ int main(int ac, char **av)
 
   // create a context on the first device:
   OWLContext context = owlContextCreate(nullptr,1);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/cmdline/s05-rtow/hostCode.cpp
+++ b/samples/cmdline/s05-rtow/hostCode.cpp
@@ -36,7 +36,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "s05-rtow.png";
 const vec2i fbSize(1600,800);
@@ -106,7 +106,7 @@ int main(int ac, char **av)
   // ##################################################################
 
   OWLContext context = owlContextCreate(nullptr,1);
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/cmdline/s06-rtow-mixedGeometries/hostCode.cpp
+++ b/samples/cmdline/s06-rtow-mixedGeometries/hostCode.cpp
@@ -37,7 +37,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "s06-rtow-mixedGeometries.png";
 const vec2i fbSize(1600,800);
@@ -196,7 +196,7 @@ int main(int ac, char **av)
   // ##################################################################
 
   OWLContext context = owlContextCreate(nullptr,1);
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/cmdline/s07-rtow-multiGPU/hostCode.cpp
+++ b/samples/cmdline/s07-rtow-multiGPU/hostCode.cpp
@@ -36,7 +36,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "s07-rtow-multiGPU.png";
 const vec2i fbSize(1600,800);
@@ -200,7 +200,7 @@ int main(int ac, char **av)
 
   int numGPUsFound = owlGetDeviceCount(context);
   LOG("Context created; owl found " << numGPUsFound << " GPUs");
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/cmdline/s08-sierpinski/hostCode.cpp
+++ b/samples/cmdline/s08-sierpinski/hostCode.cpp
@@ -35,7 +35,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 std::vector<vec3f> vertices =
   {
@@ -88,7 +88,7 @@ int main(int ac, char **av)
   owlSetMaxInstancingDepth(owl,numLevels);
 
   OWLModule module
-    = owlModuleCreate(owl,deviceCode);
+    = owlModuleCreate(owl,deviceCode_ptx);
 
   // ------------------------------------------------------------------
   OWLVarDecl lambertianMeshTypeVars[]

--- a/samples/cmdline/s09-motionBlurSimpleTriangles/hostCode.cpp
+++ b/samples/cmdline/s09-motionBlurSimpleTriangles/hostCode.cpp
@@ -34,7 +34,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const int NUM_VERTICES = 8;
 vec3f vertices0[NUM_VERTICES] =
@@ -86,7 +86,7 @@ int main(int ac, char **av)
   // create a context on the first device:
   OWLContext context = owlContextCreate(nullptr,1);
   owlEnableMotionBlur(context);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/cmdline/s10-launch3D/hostCode.cu
+++ b/samples/cmdline/s10-launch3D/hostCode.cu
@@ -37,7 +37,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "s10-launch3D.png";
 const vec2i fbSize(1600,800);
@@ -63,18 +63,18 @@ void createScene()
 {
   lambertianSpheres.push_back({Sphere{vec3f(0.f, -1000.0f, -1.f), 1000.f},
         Lambertian{vec3f(0.5f, 0.5f, 0.5f)}});
-  
+
   for (int a = -11; a < 11; a++) {
     for (int b = -11; b < 11; b++) {
       float choose_mat = rnd();
       vec3f center(a + rnd(), 0.2f, b + rnd());
-      if (choose_mat < 0.8f) 
+      if (choose_mat < 0.8f)
         lambertianSpheres.push_back({Sphere{center, 0.2f},
               Lambertian{rnd3f()*rnd3f()}});
-      else if (choose_mat < 0.95f) 
+      else if (choose_mat < 0.95f)
         metalSpheres.push_back({Sphere{center, 0.2f},
               Metal{0.5f*(1.f+rnd3f()),0.5f*rnd()}});
-      else 
+      else
         dielectricSpheres.push_back({Sphere{center, 0.2f},
               Dielectric{1.5f}});
     }
@@ -111,14 +111,14 @@ int main(int ac, char **av)
   LOG_OK(" num lambertian spheres: " << lambertianSpheres.size());
   LOG_OK(" num dielectric spheres: " << dielectricSpheres.size());
   LOG_OK(" num metal spheres     : " << metalSpheres.size());
-  
+
   // ##################################################################
   // init owl
   // ##################################################################
 
   OWLContext context = owlContextCreate(nullptr,1);
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
-  
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
+
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render
   // ##################################################################
@@ -222,7 +222,7 @@ int main(int ac, char **av)
   // ##################################################################
   // set up all *ACCELS* we need to trace into those groups
   // ##################################################################
-  
+
   OWLGeom  userGeoms[] = {
     lambertianSpheresGeom,
     metalSpheresGeom,
@@ -232,7 +232,7 @@ int main(int ac, char **av)
   OWLGroup spheresGroup
     = owlUserGeomGroupCreate(context,3,userGeoms);
   owlGroupBuildAccel(spheresGroup);
-  
+
   OWLGroup world
     = owlInstanceGroupCreate(context,1,&spheresGroup);
   owlGroupBuildAccel(world);
@@ -240,9 +240,9 @@ int main(int ac, char **av)
   // ##################################################################
   // set miss and raygen programs
   // ##################################################################
-  
+
   // -------------------------------------------------------
-  // set up miss prog 
+  // set up miss prog
   // -------------------------------------------------------
   OWLVarDecl missProgVars[] = {
     { /* sentinel to mark end of list */ }
@@ -252,7 +252,7 @@ int main(int ac, char **av)
     = owlMissProgCreate(context,module,"miss",sizeof(MissProgData),
                         missProgVars,-1);
   owlMissProgSet(context,0,missProg);
-  
+
   // ........... set variables  ............................
   /* nothing to set */
 
@@ -301,7 +301,7 @@ int main(int ac, char **av)
   owlRayGenSet3f    (rayGen,"camera.llc",   (const owl3f&)lower_left_corner);
   owlRayGenSet3f    (rayGen,"camera.horiz", (const owl3f&)horizontal);
   owlRayGenSet3f    (rayGen,"camera.vert",  (const owl3f&)vertical);
-  
+
   // ##################################################################
   // build *SBT* required to trace the groups
   // ##################################################################
@@ -315,12 +315,12 @@ int main(int ac, char **av)
   // ##################################################################
   // now that everything is ready: launch it ....
   // ##################################################################
-  
+
   LOG("launching ...");
   // owlRayGenLaunch2D(rayGen,fbSize.x,fbSize.y);
   owlBufferClear(frameBuffer);
   owlRayGenLaunch3D(rayGen,fbSize.x,fbSize.y,NUM_SAMPLES_PER_PIXEL);
-  
+
   LOG("done with launch, calling CUDA kernel to convert from float3 to rgba8 ...");
 
   // ------------------------------------------------------------------
@@ -347,9 +347,9 @@ int main(int ac, char **av)
   // ##################################################################
   // and finally, clean up
   // ##################################################################
-  
+
   LOG("destroying devicegroup ...");
   owlContextDestroy(context);
-  
+
   LOG_OK("seems all went OK; app is done, this should be the last output ...");
 }

--- a/samples/interactive/int01-simpleTriangles/hostCode.cpp
+++ b/samples/interactive/int01-simpleTriangles/hostCode.cpp
@@ -33,7 +33,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const int NUM_VERTICES = 8;
 vec3f vertices[NUM_VERTICES] =
@@ -132,7 +132,7 @@ Viewer::Viewer()
 {
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int06-mixedGeometries/hostCode.cpp
+++ b/samples/interactive/int06-mixedGeometries/hostCode.cpp
@@ -36,7 +36,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const vec2i init_fbSize(1600,800);
 const vec3f init_lookFrom(13, 2, 3);
@@ -272,7 +272,7 @@ Viewer::Viewer()
   // ##################################################################
 
   context = owlContextCreate(nullptr,1);
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int07-whitted/hostCode.cpp
+++ b/samples/interactive/int07-whitted/hostCode.cpp
@@ -36,7 +36,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const vec2i init_fbSize(1600, 800);
 const vec3f init_lookFrom(-4.3f, 3.3f, -5.0f);
@@ -241,7 +241,7 @@ Viewer::Viewer()
     // ##################################################################
 
     context = owlContextCreate(nullptr, 1);
-    OWLModule  module = owlModuleCreate(context, deviceCode);
+    OWLModule  module = owlModuleCreate(context, deviceCode_ptx);
 
     // ##################################################################
     // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int10-texturedTriangles/hostCode.cpp
+++ b/samples/interactive/int10-texturedTriangles/hostCode.cpp
@@ -33,7 +33,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 std::vector<vec3f> vertices;
 std::vector<vec2f> texCoords;
@@ -137,7 +137,7 @@ Viewer::Viewer()
 {
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int11-rotatingBoxes/hostCode.cpp
+++ b/samples/interactive/int11-rotatingBoxes/hostCode.cpp
@@ -37,7 +37,7 @@ using namespace owl::common;
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 struct Mesh {
   std::vector<vec3f> vertices;
@@ -251,7 +251,7 @@ Viewer::Viewer()
 {
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int12-switchingTextureSets/hostCode.cpp
+++ b/samples/interactive/int12-switchingTextureSets/hostCode.cpp
@@ -37,7 +37,7 @@ using namespace owl::common;
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 struct Mesh {
   std::vector<vec3f> vertices;
@@ -270,7 +270,7 @@ Viewer::Viewer()
 {
   // create a context on the first device:
   context = owlContextCreate(nullptr,0);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int13-motionBlurInstances/hostCode.cpp
+++ b/samples/interactive/int13-motionBlurInstances/hostCode.cpp
@@ -37,7 +37,7 @@ using namespace owl::common;
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 struct Mesh {
   std::vector<vec3f> vertices;
@@ -258,7 +258,7 @@ Viewer::Viewer()
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
   owlEnableMotionBlur(context);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/samples/interactive/int15-cookBilliardScene/hostCode.cpp
+++ b/samples/interactive/int15-cookBilliardScene/hostCode.cpp
@@ -41,7 +41,7 @@ using namespace owl::common;
   std::cout << "#owl.sample(main): " << message << std::endl;   \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 namespace cameraTriangle {
   const vec3f init_lookFrom(0.216657f,-9.58095f,3.37295f);
@@ -225,7 +225,7 @@ Viewer::Viewer(Viewer::Setup stp)
   // create a context on the first device:
   context = owlContextCreate(nullptr,1);
   owlContextSetRayTypeCount(context,2);
-  OWLModule module = owlModuleCreate(context,deviceCode);
+  OWLModule module = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/tests/owl-as-subdirectory/CMakeLists.txt
+++ b/tests/owl-as-subdirectory/CMakeLists.txt
@@ -25,21 +25,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(owlSubmoduleTest LANGUAGES C CXX CUDA)
 
-# This is the same as someone calling add_subdirectory(path/to/OWL) submodule
-add_subdirectory(
-  ${CMAKE_SOURCE_DIR}/../..
-  ${CMAKE_BINARY_DIR}/owl
-)
+# This is the same as someone calling add_subdirectory(path/to/OWL) with OWL as
+# a submodule
+add_subdirectory(${CMAKE_SOURCE_DIR}/../.. ${CMAKE_BINARY_DIR}/owl)
 
 # Parent projects must include embed_ptx.cmake in order to use it
 include(embed_ptx)
-
-# NOTE(jda) - Hack here to get stb_image...would be provided by parent project
-#             normally.
-add_subdirectory(
-  ${CMAKE_SOURCE_DIR}/../../3rdParty/stb_image
-  ${CMAKE_BINARY_DIR}/stb_image
-)
 
 # Build the many-spheres test to verify things work
 add_subdirectory(

--- a/tests/t01-many-spheres/CMakeLists.txt
+++ b/tests/t01-many-spheres/CMakeLists.txt
@@ -17,6 +17,8 @@
 embed_ptx(
   OUTPUT_TARGET
     test01-manySpheres-ptx
+  EMBEDDED_SYMBOL_NAMES
+    ptxCode
   PTX_LINK_LIBRARIES
     owl::owl
   SOURCES

--- a/tests/t01-many-spheres/hostCode.cpp
+++ b/tests/t01-many-spheres/hostCode.cpp
@@ -35,7 +35,7 @@
   std::cout << "#ll.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode_ptx[];
+extern "C" char ptxCode[];
 
 const char *outFileName = "t01-manySpheres.png";
 const vec2i fbSize(2048,2048);
@@ -87,7 +87,7 @@ int main(int ac, char **av)
   // ##################################################################
 
   OWLContext context = owlContextCreate();
-  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
+  OWLModule  module  = owlModuleCreate(context,ptxCode);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/tests/t01-many-spheres/hostCode.cpp
+++ b/tests/t01-many-spheres/hostCode.cpp
@@ -35,7 +35,7 @@
   std::cout << "#ll.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "t01-manySpheres.png";
 const vec2i fbSize(2048,2048);
@@ -87,7 +87,7 @@ int main(int ac, char **av)
   // ##################################################################
 
   OWLContext context = owlContextCreate();
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render

--- a/tests/t02-group-rebuilds/hostCode.cpp
+++ b/tests/t02-group-rebuilds/hostCode.cpp
@@ -37,7 +37,7 @@
   std::cout << "#owl.sample(main): " << message << std::endl;    \
   std::cout << OWL_TERMINAL_DEFAULT;
 
-extern "C" char deviceCode[];
+extern "C" char deviceCode_ptx[];
 
 const char *outFileName = "t02-group-rebuilds.png";
 const vec2i fbSize(600,300);
@@ -201,7 +201,7 @@ int main(int ac, char **av)
   // ##################################################################
 
   OWLContext context = owlContextCreate(nullptr,1);
-  OWLModule  module  = owlModuleCreate(context,deviceCode);
+  OWLModule  module  = owlModuleCreate(context,deviceCode_ptx);
 
   // ##################################################################
   // set up all the *GEOMETRY* graph we want to render


### PR DESCRIPTION
Minor updates around the new CMake changes:

- `stb_image` is always available, so I removed it from the [external test](https://github.com/jeffamstutz/owl/blob/jda/embed_ptx_updates/tests/owl-as-subdirectory/CMakeLists.txt)
- A `_ptx` postfix was given to the C symbol of the embedded PTX to make it more obvious to what it is (see commments in #136)
- No longer use `find_file()` to resolve `run_bin2c.cmake`'s location. Instead do this with a hard coded location relative to `embed_ptx.cmake`