### PR TITLE
Expose GAS and IAS build flags and also change default flags to favor low memory usage

### DIFF
--- a/owl/Context.cpp
+++ b/owl/Context.cpp
@@ -291,10 +291,10 @@ namespace owl {
     return gg;
   }
   
-  GeomGroup::SP Context::userGeomGroupCreate(size_t numChildren)
+  GeomGroup::SP Context::userGeomGroupCreate(size_t numChildren, unsigned int buildFlags)
   {
     GeomGroup::SP gg
-      = std::make_shared<UserGeomGroup>(this,numChildren);
+      = std::make_shared<UserGeomGroup>(this,numChildren,buildFlags);
     gg->createDeviceData(getDevices());
     return gg;
   }

--- a/owl/Context.cpp
+++ b/owl/Context.cpp
@@ -283,10 +283,10 @@ namespace owl {
   }
   
   
-  GeomGroup::SP Context::trianglesGeomGroupCreate(size_t numChildren)
+  GeomGroup::SP Context::trianglesGeomGroupCreate(size_t numChildren, unsigned int buildFlags)
   {
     GeomGroup::SP gg
-      = std::make_shared<TrianglesGeomGroup>(this,numChildren);
+      = std::make_shared<TrianglesGeomGroup>(this,numChildren,buildFlags);
     gg->createDeviceData(getDevices());
     return gg;
   }

--- a/owl/Context.h
+++ b/owl/Context.h
@@ -140,7 +140,7 @@ namespace owl {
       different programs, etc, but must all be of "OWL_TRIANGLES"
       kind */
     GeomGroup::SP
-    trianglesGeomGroupCreate(size_t numChildren);
+    trianglesGeomGroupCreate(size_t numChildren, unsigned int buildFlags);
     
     /*! create a new *user* geometry group that will eventually create
       a BVH over all the user geoms / custom prims in all its child

--- a/owl/Context.h
+++ b/owl/Context.h
@@ -146,9 +146,9 @@ namespace owl {
       a BVH over all the user geoms / custom prims in all its child
       geometries. only UserGeom's can be added to this group. These
       user geoms can all have different types, different programs,
-      etc, but must all be of "OWL_TRIANGLES" kind */
+      etc, but must all be of "OWL_GEOMETRY_USER" kind */
     GeomGroup::SP
-    userGeomGroupCreate(size_t numChildren);
+    userGeomGroupCreate(size_t numChildren, unsigned int buildFlags);
 
     /*! create a new device buffer of given data type and count; if
       init is non-null it will be used to populoate this

--- a/owl/InstanceGroup.cpp
+++ b/owl/InstanceGroup.cpp
@@ -39,9 +39,11 @@ namespace owl {
 
   InstanceGroup::InstanceGroup(Context *const context,
                                size_t numChildren,
-                               Group::SP      *groups)
+                               Group::SP *groups,
+                               unsigned int _buildFlags)
     : Group(context,context->groups),
-      children(numChildren)
+      children(numChildren),
+      buildFlags( (_buildFlags > 0) ? _buildFlags : defaultBuildFlags)
   {
     std::vector<uint32_t> childIDs;
     if (groups) {
@@ -156,6 +158,9 @@ namespace owl {
     if (children.size() > maxInstsPerIAS)
       throw std::runtime_error("number of children in instance group exceeds "
                                "OptiX's MAX_INSTANCES_PER_IAS limit");
+
+    if (!FULL_REBUILD && !(buildFlags & OPTIX_BUILD_FLAG_ALLOW_UPDATE))
+      throw std::runtime_error("trying to refit an accel struct that was not built with OPTIX_BUILD_FLAG_ALLOW_UPDATE");
     
     if (FULL_REBUILD) {
       dd.memFinal = 0;
@@ -223,11 +228,8 @@ namespace owl {
     // ==================================================================
     // set up accel uptions
     // ==================================================================
-    accelOptions.buildFlags =
-      OPTIX_BUILD_FLAG_PREFER_FAST_TRACE
-      |
-      OPTIX_BUILD_FLAG_ALLOW_UPDATE
-      ;
+    accelOptions.buildFlags = this->buildFlags;
+
     accelOptions.motionOptions.numKeys = 1;
     if (FULL_REBUILD)
       accelOptions.operation            = OPTIX_BUILD_OPERATION_BUILD;

--- a/owl/InstanceGroup.h
+++ b/owl/InstanceGroup.h
@@ -43,7 +43,8 @@ namespace owl {
     /*! construct with given array of groups - transforms can be specified later */
     InstanceGroup(Context *const context,
                   size_t numChildren,
-                  Group::SP      *groups);
+                  Group::SP *groups,
+                  unsigned int buildFlags);
 
     /*! pretty-printer, for printf-debugging */
     std::string toString() const override;
@@ -103,6 +104,12 @@ namespace owl {
       specified we/optix will fill in automatically using
       visibility=255 */
     std::vector<uint8_t> visibilityMasks;
+
+    constexpr static unsigned int defaultBuildFlags = 
+        OPTIX_BUILD_FLAG_PREFER_FAST_TRACE;
+
+    protected:
+    const unsigned int buildFlags;
 
   };
 

--- a/owl/TrianglesGeomGroup.cpp
+++ b/owl/TrianglesGeomGroup.cpp
@@ -88,6 +88,9 @@ namespace owl {
     if (!FULL_REBUILD && dd.bvhMemory.empty())
       throw std::runtime_error("trying to refit an accel struct that has not been previously built");
 
+    if (!FULL_REBUILD && !(buildFlags & OPTIX_BUILD_FLAG_ALLOW_UPDATE))
+      throw std::runtime_error("trying to refit an accel struct that was not built with OPTIX_BUILD_FLAG_ALLOW_UPDATE");
+
     if (FULL_REBUILD) {
       dd.memFinal = 0;
       dd.memPeak = 0;

--- a/owl/TrianglesGeomGroup.cpp
+++ b/owl/TrianglesGeomGroup.cpp
@@ -39,10 +39,12 @@ namespace owl {
     return "TrianglesGeomGroup";
   }
   
-  /*! constructor - passthroughto parent class */
+  /*! constructor - mostly passthrough to parent class */
   TrianglesGeomGroup::TrianglesGeomGroup(Context *const context,
-                                         size_t numChildren)
-    : GeomGroup(context,numChildren)
+                                         size_t numChildren,
+                                         unsigned int _buildFlags)
+    : GeomGroup(context,numChildren), 
+    buildFlags( (_buildFlags > 0) ? _buildFlags : defaultBuildFlags)
   {}
   
   void TrianglesGeomGroup::updateMotionBounds()
@@ -179,10 +181,7 @@ namespace owl {
     // first: compute temp memory for bvh
     // ------------------------------------------------------------------
     OptixAccelBuildOptions accelOptions = {};
-    accelOptions.buildFlags =
-      OPTIX_BUILD_FLAG_ALLOW_UPDATE |
-      OPTIX_BUILD_FLAG_PREFER_FAST_TRACE |
-      OPTIX_BUILD_FLAG_ALLOW_COMPACTION;
+    accelOptions.buildFlags = this->buildFlags;
     
     accelOptions.motionOptions.numKeys   = numKeys;
     accelOptions.motionOptions.flags     = 0;

--- a/owl/TrianglesGeomGroup.cpp
+++ b/owl/TrianglesGeomGroup.cpp
@@ -324,16 +324,8 @@ namespace owl {
       dd.memFinal = dd.bvhMemory.size();
     }
     CUDA_SYNC_CHECK();
-      
-    // ==================================================================
-    // aaaaaand .... clean up
-    // ==================================================================
-    if (FULL_REBUILD && allowCompaction) {
-      outputBuffer.free(); // << the UNcompacted, temporary output buffer
-      compactedSizeBuffer.free();
-    }
-    tempBuffer.free();
 
+    
     LOG_OK("successfully build triangles geom group accel");
   }
   

--- a/owl/TrianglesGeomGroup.h
+++ b/owl/TrianglesGeomGroup.h
@@ -42,8 +42,7 @@ namespace owl {
 
     constexpr static unsigned int defaultBuildFlags = 
         OPTIX_BUILD_FLAG_PREFER_FAST_TRACE |
-        OPTIX_BUILD_FLAG_ALLOW_COMPACTION |
-        OPTIX_BUILD_FLAG_ALLOW_RANDOM_VERTEX_ACCESS;
+        OPTIX_BUILD_FLAG_ALLOW_COMPACTION;
 
     protected:
     const unsigned int buildFlags;

--- a/owl/TrianglesGeomGroup.h
+++ b/owl/TrianglesGeomGroup.h
@@ -24,7 +24,7 @@ namespace owl {
   struct TrianglesGeomGroup : public GeomGroup {
 
     /*! constructor - passthroughto parent class */
-    TrianglesGeomGroup(Context *const context, size_t numChildren);
+    TrianglesGeomGroup(Context *const context, size_t numChildren, unsigned int buildFlags);
     
     /*! pretty-printer, for printf-debugging */
     std::string toString() const override;
@@ -39,6 +39,14 @@ namespace owl {
     /*! low-level accel structure builder for given device */
     template<bool FULL_REBUILD>
     void buildAccelOn(const DeviceContext::SP &device);
+
+    constexpr static unsigned int defaultBuildFlags = 
+        OPTIX_BUILD_FLAG_PREFER_FAST_TRACE |
+        OPTIX_BUILD_FLAG_ALLOW_COMPACTION |
+        OPTIX_BUILD_FLAG_ALLOW_RANDOM_VERTEX_ACCESS;
+
+    protected:
+    const unsigned int buildFlags;
   };
 
 } // ::owl

--- a/owl/UserGeomGroup.cpp
+++ b/owl/UserGeomGroup.cpp
@@ -315,11 +315,6 @@ namespace owl {
       
     CUDA_SYNC_CHECK();
 
-    // ==================================================================
-    // finish - clean up
-    // ==================================================================
-
-    tempBuffer.free();
 
     LOG_OK("successfully built user geom group accel");
 

--- a/owl/UserGeomGroup.cpp
+++ b/owl/UserGeomGroup.cpp
@@ -32,8 +32,10 @@
 namespace owl {
   
   UserGeomGroup::UserGeomGroup(Context *const context,
-                               size_t numChildren)
-    : GeomGroup(context,numChildren)
+                               size_t numChildren,
+                               unsigned int _buildFlags)
+    : GeomGroup(context,numChildren),
+    buildFlags( (_buildFlags > 0) ? _buildFlags : defaultBuildFlags)
   {}
 
   void UserGeomGroup::buildOrRefit(bool FULL_REBUILD)
@@ -72,18 +74,16 @@ namespace owl {
     if (FULL_REBUILD && !dd.bvhMemory.empty())
       dd.bvhMemory.free();
 
+    if (!FULL_REBUILD && dd.bvhMemory.empty())
+      throw std::runtime_error("trying to refit an accel struct that has not been previously built");
+
+    if (!FULL_REBUILD && !(buildFlags & OPTIX_BUILD_FLAG_ALLOW_UPDATE))
+      throw std::runtime_error("trying to refit an accel struct that was not built with OPTIX_BUILD_FLAG_ALLOW_UPDATE");
+
     if (FULL_REBUILD) {
       dd.memFinal = 0;
       dd.memPeak = 0;
     }
-
-    if (!FULL_REBUILD && dd.bvhMemory.empty())
-      throw std::runtime_error("trying to refit an accel struct that has not been previously built");
-    // // assert("check does not yet exist" && dd.traversable == 0);
-    // if (FULL_REBUILD)
-    //   assert("check does not yet exist on first build " && dd.bvhMemory.empty());
-    // else
-    //   assert("check DOES exist on first build " && !dd.bvhMemory.empty());
       
     SetActiveGPU forLifeTime(device);
     LOG("building user accel over "
@@ -98,11 +98,11 @@ namespace owl {
        sizeof(maxPrimsPerGAS));
     
     // ==================================================================
-    // create triangle inputs
+    // create user geom inputs
     // ==================================================================
     //! the N build inputs that go into the builder
     std::vector<OptixBuildInput> userGeomInputs(geometries.size());
-    /*! *arrays* of the vertex pointers - the buildinputs cointina
+    /*! *arrays* of the vertex pointers - the buildinputs contain
      *pointers* to the pointers, so need a temp copy here */
     std::vector<CUdeviceptr> boundsPointers(geometries.size());
 
@@ -164,12 +164,8 @@ namespace owl {
     // first: compute temp memory for bvh
     // ------------------------------------------------------------------
     OptixAccelBuildOptions accelOptions = {};
-    accelOptions.buildFlags             =
-      // OPTIX_BUILD_FLAG_PREFER_FAST_BUILD
-      OPTIX_BUILD_FLAG_ALLOW_UPDATE
-      |
-      OPTIX_BUILD_FLAG_PREFER_FAST_TRACE
-      ;
+    accelOptions.buildFlags = this->buildFlags;
+
     accelOptions.motionOptions.numKeys  = 1;
     if (FULL_REBUILD)
       accelOptions.operation            = OPTIX_BUILD_OPERATION_BUILD;
@@ -209,8 +205,93 @@ namespace owl {
 
     if (FULL_REBUILD) {
       dd.memPeak += tempBuffer.size();
-      // alloc only on first rebuild
-      dd.bvhMemory.alloc(blasBufferSizes.outputSizeInBytes);
+    }
+
+    const bool allowCompaction = (buildFlags & OPTIX_BUILD_FLAG_ALLOW_COMPACTION);
+
+    // Optional buffers only used when compaction is allowed
+    DeviceMemory outputBuffer;
+    DeviceMemory compactedSizeBuffer;
+
+    // Allocate output buffer for initial build
+    if (FULL_REBUILD) {
+      if (allowCompaction) {
+        outputBuffer.alloc(blasBufferSizes.outputSizeInBytes);
+        dd.memPeak += outputBuffer.size();
+      } else {
+        dd.bvhMemory.alloc(blasBufferSizes.outputSizeInBytes);
+        dd.memPeak += dd.bvhMemory.size();
+        dd.memFinal = dd.bvhMemory.size();
+      }
+    }
+
+    // Build or refit
+
+    if (FULL_REBUILD && allowCompaction) {
+
+      compactedSizeBuffer.alloc(sizeof(uint64_t));
+      dd.memPeak += compactedSizeBuffer.size();
+
+      OptixAccelEmitDesc emitDesc;
+      emitDesc.type = OPTIX_PROPERTY_TYPE_COMPACTED_SIZE;
+      emitDesc.result = (CUdeviceptr)compactedSizeBuffer.get();
+
+      OPTIX_CHECK(optixAccelBuild(optixContext,
+                                  /* todo: stream */0,
+                                  &accelOptions,
+                                  // array of build inputs:
+                                  userGeomInputs.data(),
+                                  (uint32_t)userGeomInputs.size(),
+                                  // buffer of temp memory:
+                                  (CUdeviceptr)tempBuffer.get(),
+                                  tempBuffer.size(),
+                                  // where we store initial, uncomp bvh:
+                                  (CUdeviceptr)outputBuffer.get(),
+                                  outputBuffer.size(),
+                                  /* the dd.traversable we're building: */ 
+                                  &dd.traversable,
+                                  /* we're also querying compacted size: */
+                                  &emitDesc,1u
+                                  ));
+    } else {
+      OPTIX_CHECK(optixAccelBuild(optixContext,
+                                  /* todo: stream */0,
+                                  &accelOptions,
+                                  // array of build inputs:
+                                  userGeomInputs.data(),
+                                  (uint32_t)userGeomInputs.size(),
+                                  // buffer of temp memory:
+                                  (CUdeviceptr)tempBuffer.get(),
+                                  tempBuffer.size(),
+                                  // where we store initial, uncomp bvh:
+                                  (CUdeviceptr)dd.bvhMemory.get(),
+                                  dd.bvhMemory.size(),
+                                  /* the dd.traversable we're building: */ 
+                                  &dd.traversable,
+                                  /* not querying anything */
+                                  nullptr,0
+                                  ));
+    }
+    CUDA_SYNC_CHECK();
+
+    // ==================================================================
+    // perform compaction
+    // ==================================================================
+    
+    if (FULL_REBUILD && allowCompaction) {
+      // download builder's compacted size from device
+      uint64_t compactedSize;
+      compactedSizeBuffer.download(&compactedSize);
+      
+      dd.bvhMemory.alloc(compactedSize);
+      // ... and perform compaction
+      OPTIX_CALL(AccelCompact(device->optixContext,
+                              /*TODO: stream:*/0,
+                              // OPTIX_COPY_MODE_COMPACT,
+                              dd.traversable,
+                              (CUdeviceptr)dd.bvhMemory.get(),
+                              dd.bvhMemory.size(),
+                              &dd.traversable));
       dd.memPeak += dd.bvhMemory.size();
       dd.memFinal = dd.bvhMemory.size();
     }

--- a/owl/UserGeomGroup.h
+++ b/owl/UserGeomGroup.h
@@ -26,7 +26,8 @@ namespace owl {
   struct UserGeomGroup : public GeomGroup {
 
     UserGeomGroup(Context *const context,
-                   size_t numChildren);
+                   size_t numChildren,
+                   unsigned int buildFlags);
     virtual std::string toString() const { return "UserGeomGroup"; }
 
     /*! build() and refit() share most of their code; this functoin
@@ -40,6 +41,14 @@ namespace owl {
     /*! low-level accel structure builder for given device */
     template<bool FULL_REBUILD>
     void buildAccelOn(const DeviceContext::SP &device);
+
+    constexpr static unsigned int defaultBuildFlags = 
+        OPTIX_BUILD_FLAG_PREFER_FAST_TRACE |
+        OPTIX_BUILD_FLAG_ALLOW_COMPACTION;
+
+    protected:
+    const unsigned int buildFlags;
+
   };
 
 } // ::owl

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -473,11 +473,12 @@ owlMissProgCreate(OWLContext _context,
 OWL_API OWLGroup
 owlTrianglesGeomGroupCreate(OWLContext _context,
                             size_t numGeometries,
-                            OWLGeom *initValues)
+                            OWLGeom *initValues,
+                            unsigned int buildFlags)
 {
   LOG_API_CALL();
   APIContext::SP context = checkGet(_context);
-  GeomGroup::SP  group = context->trianglesGeomGroupCreate(numGeometries);
+  GeomGroup::SP  group = context->trianglesGeomGroupCreate(numGeometries, buildFlags);
   assert(group);
     
   OWLGroup _group = (OWLGroup)context->createHandle(group);

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -496,11 +496,12 @@ owlTrianglesGeomGroupCreate(OWLContext _context,
 OWL_API OWLGroup
 owlUserGeomGroupCreate(OWLContext _context,
                        size_t numGeometries,
-                       OWLGeom *initValues)
+                       OWLGeom *initValues,
+                       unsigned int buildFlags)
 {
   LOG_API_CALL();
   APIContext::SP context = checkGet(_context);
-  GeomGroup::SP  group   = context->userGeomGroupCreate(numGeometries);
+  GeomGroup::SP  group   = context->userGeomGroupCreate(numGeometries, buildFlags);
   assert(group);
     
   OWLGroup _group = (OWLGroup)context->createHandle(group);

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -547,7 +547,9 @@ owlInstanceGroupCreate(OWLContext _context,
                          null, or an array of size numInstnaces, of
                          the format specified */
                        const float    *initTransforms,
-                       OWLMatrixFormat matrixFormat)
+                       OWLMatrixFormat matrixFormat,
+                       
+                       unsigned int buildFlags)
 {
   LOG_API_CALL();
   std::vector<Group::SP> initGroups;
@@ -557,7 +559,7 @@ owlInstanceGroupCreate(OWLContext _context,
   InstanceGroup::SP  group
     = std::make_shared<InstanceGroup>
     (context.get(),numInstances,
-     __initGroups);
+     __initGroups, buildFlags);
   assert(group);
   group->createDeviceData(context->getDevices());
 

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -579,7 +579,11 @@ owlInstanceGroupCreate(OWLContext context,
                          null, or an array of size numInstnaces, of
                          the format specified */
                        const float    *initTransforms  OWL_IF_CPP(= nullptr),
-                       OWLMatrixFormat matrixFormat    OWL_IF_CPP(=OWL_MATRIX_FORMAT_OWL)
+                       OWLMatrixFormat matrixFormat    OWL_IF_CPP(=OWL_MATRIX_FORMAT_OWL),
+
+                       /*! A combination of OptixBuildFlags.  The default
+                         of 0 means to use OWL default build flags.*/
+                       unsigned int buildFlags OWL_IF_CPP(=0)
                        );
 
                        

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -497,11 +497,15 @@ owlMissProgSet(OWLContext  context,
   geometries. Every geom in this array must be a valid owl geometry
   created with owlGeomCreate, and must be of a OWL_GEOM_USER
   type.
+
+  \param buildFlags A combination of OptixBuildFlags.  The default
+  of 0 means to use OWL default build flags.
 */
 OWL_API OWLGroup
 owlUserGeomGroupCreate(OWLContext context,
                        size_t     numGeometries,
-                       OWLGeom   *arrayOfChildGeoms);
+                       OWLGeom   *arrayOfChildGeoms,
+                       unsigned int buildFlags OWL_IF_CPP(=0));
 
 
 // ------------------------------------------------------------------

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -515,11 +515,15 @@ owlUserGeomGroupCreate(OWLContext context,
   geometries. Every geom in this array must be a valid owl geometry
   created with owlGeomCreate, and must be of a OWL_GEOM_TRIANGLES
   type.
+
+  \param buildFlags A combination of OptixBuildFlags.  The default
+  of 0 means to use OWL default build flags.
 */
 OWL_API OWLGroup
 owlTrianglesGeomGroupCreate(OWLContext context,
                             size_t     numGeometries,
-                            OWLGeom   *initValues);
+                            OWLGeom   *initValues,
+                            unsigned int buildFlags OWL_IF_CPP(=0));
 
 // ------------------------------------------------------------------
 /*! create a new instance group with given number of instances. The

--- a/samples/interactive/int11-rotatingBoxes/hostCode.cpp
+++ b/samples/interactive/int11-rotatingBoxes/hostCode.cpp
@@ -302,7 +302,8 @@ Viewer::Viewer()
                              groups.data(),
                              nullptr,
                              (const float*)boxTransforms.data(),
-                             OWL_MATRIX_FORMAT_OWL);
+                             OWL_MATRIX_FORMAT_OWL,
+                             OPTIX_BUILD_FLAG_PREFER_FAST_TRACE | OPTIX_BUILD_FLAG_ALLOW_UPDATE);
   owlGroupBuildAccel(world);
 
   // ##################################################################


### PR DESCRIPTION
The constructors for TrianglesGeomGroup, UserGeomGroup, and InstanceGeomGroup all take a `buildFlags` argument now. The default argument value is 0, meaning use internal build flags to allow compaction and disallow refit (ALLOW_UPDATE=0).

In the version of OptiX we tested (7.3), ALLOW_UPDATE=1 has a memory penalty of almost 2x for large triangle-based GASes with millions of triangles.  This led us to disable this flag by default to save memory.  We also set similar defaults for UserGeomGroups and InstanceGroups for consistency even though the memory ratio is smaller there.

Only a single existing sample uses refit, and we patched that up to modify the build flag to allow refit in that specific sample. 
