### PR TITLE
Refactor CUDA_ macros names as per #141

### DIFF
--- a/owl/Buffer.cpp
+++ b/owl/Buffer.cpp
@@ -94,7 +94,7 @@ namespace owl {
 
     SetActiveGPU forLifeTime(device);
 
-    CUDA_CALL_NOTHROW(Free(d_pointer));
+    OWL_CUDA_CALL_NOTHROW(Free(d_pointer));
     d_pointer = nullptr;
   }
   
@@ -121,7 +121,7 @@ namespace owl {
   {
     for (auto dd : deviceData)
       dd->as<DeviceBuffer::DeviceData>().clear();
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
   }
   
   void DeviceBuffer::upload(const void *hostPtr, size_t offset, int64_t count)
@@ -129,14 +129,14 @@ namespace owl {
     assert(deviceData.size() == context->deviceCount());
     for (auto dd : deviceData)
       dd->as<DeviceBuffer::DeviceData>().uploadAsync(hostPtr, offset, count);
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
   }
   
   void DeviceBuffer::upload(const int deviceID, const void *hostPtr, size_t offset, int64_t count) 
   {
     assert(deviceID < (int)deviceData.size());
     deviceData[deviceID]->as<DeviceBuffer::DeviceData>().uploadAsync(hostPtr, offset, count);
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
   }
   
 
@@ -156,11 +156,11 @@ namespace owl {
   {
     SetActiveGPU forLifeTime(device);
     if (d_pointer) {
-      CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
+      OWL_CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
     }
 
     if (parent->elementCount)
-      CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(cudaTextureObject_t)));
+      OWL_CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(cudaTextureObject_t)));
   }
 
   void DeviceBuffer::DeviceDataForTextures::clear() 
@@ -185,7 +185,7 @@ namespace owl {
       } else
         hostHandles[i] = nullptr;
 
-    CUDA_CALL(MemcpyAsync((char*)d_pointer + offset, devRep.data(),
+    OWL_CUDA_CALL(MemcpyAsync((char*)d_pointer + offset, devRep.data(),
                           devRep.size()*sizeof(devRep[0]),
                           cudaMemcpyDefault,
                           device->getStream()));
@@ -201,11 +201,11 @@ namespace owl {
     SetActiveGPU forLifeTime(device);
     
     if (d_pointer) {
-      CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
+      OWL_CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
     }
 
     if (parent->elementCount) {
-      CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(device::Buffer)));
+      OWL_CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(device::Buffer)));
     }
   }
   
@@ -233,7 +233,7 @@ namespace owl {
         devRep[i].count   = 0;
       }
 
-    CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,devRep.data(),
+    OWL_CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,devRep.data(),
                           devRep.size()*sizeof(devRep[0]),
                           cudaMemcpyDefault,
                           device->getStream()));
@@ -252,10 +252,10 @@ namespace owl {
   {
     SetActiveGPU forLifeTime(device);
     
-    if (d_pointer) { CUDA_CALL(Free(d_pointer)); d_pointer = nullptr; }
+    if (d_pointer) { OWL_CUDA_CALL(Free(d_pointer)); d_pointer = nullptr; }
 
     if (parent->elementCount)
-      CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(OptixTraversableHandle)));
+      OWL_CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeof(OptixTraversableHandle)));
   }
   
   void DeviceBuffer::DeviceDataForGroups::uploadAsync(const void *hostDataPtr, size_t offset, int64_t count) 
@@ -282,7 +282,7 @@ namespace owl {
         devRep[i] = 0;
       }
 
-    CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,devRep.data(),
+    OWL_CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,devRep.data(),
                           devRep.size()*sizeof(devRep[0]),
                           cudaMemcpyDefault,
                           device->getStream()));
@@ -294,7 +294,7 @@ namespace owl {
     SetActiveGPU forLifeTime(device);
     
     if (parent->elementCount) {
-      CUDA_CALL(Memset(d_pointer,0,parent->elementCount*sizeOf(parent->type)));
+      OWL_CUDA_CALL(Memset(d_pointer,0,parent->elementCount*sizeOf(parent->type)));
     }
   }
   
@@ -305,11 +305,11 @@ namespace owl {
     SetActiveGPU forLifeTime(device);
     
     if (d_pointer) {
-      CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
+      OWL_CUDA_CALL(Free(d_pointer)); d_pointer = nullptr;
     }
 
     if (parent->elementCount) {
-      CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeOf(parent->type)));
+      OWL_CUDA_CALL(Malloc(&d_pointer,parent->elementCount*sizeOf(parent->type)));
     }
   }
   
@@ -317,7 +317,7 @@ namespace owl {
   {
     SetActiveGPU forLifeTime(device);
     
-    CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,hostDataPtr,
+    OWL_CUDA_CALL(MemcpyAsync((char*)d_pointer + offset,hostDataPtr,
                           ((count == -1) ? parent->elementCount : count)*sizeOf(parent->type),
                           cudaMemcpyDefault,
                           device->getStream()));
@@ -339,7 +339,7 @@ namespace owl {
   HostPinnedBuffer::~HostPinnedBuffer()
   {
     if (cudaHostPinnedMem) {
-      CUDA_CALL_NOTHROW(FreeHost(cudaHostPinnedMem));
+      OWL_CUDA_CALL_NOTHROW(FreeHost(cudaHostPinnedMem));
       cudaHostPinnedMem = nullptr;
     }
   }
@@ -354,13 +354,13 @@ namespace owl {
   void HostPinnedBuffer::resize(size_t newElementCount)
   {
     if (cudaHostPinnedMem) {
-      CUDA_CALL_NOTHROW(FreeHost(cudaHostPinnedMem));
+      OWL_CUDA_CALL_NOTHROW(FreeHost(cudaHostPinnedMem));
       cudaHostPinnedMem = nullptr;
     }
 
     elementCount = newElementCount;
     if (newElementCount > 0)
-      CUDA_CALL(MallocHost((void**)&cudaHostPinnedMem, sizeInBytes()));
+      OWL_CUDA_CALL(MallocHost((void**)&cudaHostPinnedMem, sizeInBytes()));
 
     for (auto device : context->getDevices()) {
       getDD(device).d_pointer = cudaHostPinnedMem;
@@ -398,7 +398,7 @@ namespace owl {
   ManagedMemoryBuffer::~ManagedMemoryBuffer()
   {
     if (cudaManagedMem) {
-      CUDA_CALL_NOTHROW(Free(cudaManagedMem));
+      OWL_CUDA_CALL_NOTHROW(Free(cudaManagedMem));
       cudaManagedMem = 0;
     }
   }
@@ -412,13 +412,13 @@ namespace owl {
   void ManagedMemoryBuffer::resize(size_t newElementCount)
   {
     if (cudaManagedMem) {
-      CUDA_CALL_NOTHROW(Free(cudaManagedMem));
+      OWL_CUDA_CALL_NOTHROW(Free(cudaManagedMem));
       cudaManagedMem = 0;
     }
     
     elementCount = newElementCount;
     if (newElementCount > 0) {
-      CUDA_CALL(MallocManaged((void**)&cudaManagedMem, sizeInBytes()));
+      OWL_CUDA_CALL(MallocManaged((void**)&cudaManagedMem, sizeInBytes()));
       unsigned char *mem_end = (unsigned char *)cudaManagedMem + sizeInBytes();
       size_t pageSize = 16*1024*1024;
       int pageID = 0;
@@ -460,7 +460,7 @@ namespace owl {
   void ManagedMemoryBuffer::clear()
   {
     assert(cudaManagedMem);
-    CUDA_CALL(Memset((char*)cudaManagedMem, 0, sizeInBytes()));
+    OWL_CUDA_CALL(Memset((char*)cudaManagedMem, 0, sizeInBytes()));
   }
   
   void ManagedMemoryBuffer::upload(const void *hostPtr, size_t offset, int64_t count)
@@ -517,16 +517,16 @@ namespace owl {
   {
     DeviceContext::SP device = context->getDevice(deviceID);
     DeviceData &dd = getDD(device);
-    CUDA_CHECK(cudaGraphicsMapResources(1, &resource, stream));
+    OWL_CUDA_CHECK(cudaGraphicsMapResources(1, &resource, stream));
     size_t size = 0;
-    CUDA_CHECK(cudaGraphicsResourceGetMappedPointer(&dd.d_pointer, &size, resource));
+    OWL_CUDA_CHECK(cudaGraphicsResourceGetMappedPointer(&dd.d_pointer, &size, resource));
   }
 
   void GraphicsBuffer::unmap(const int deviceID, CUstream stream)
   {
     DeviceContext::SP device = context->getDevice(deviceID);
     DeviceData &dd = getDD(device);
-    CUDA_CHECK(cudaGraphicsUnmapResources(1, &resource, stream));
+    OWL_CUDA_CHECK(cudaGraphicsUnmapResources(1, &resource, stream));
     dd.d_pointer = nullptr;
   }
 

--- a/owl/DeviceContext.cpp
+++ b/owl/DeviceContext.cpp
@@ -115,7 +115,7 @@ namespace owl {
     cudaFree(0);
     
     int totalNumDevicesAvailable = 0;
-    CUDA_CALL(GetDeviceCount(&totalNumDevicesAvailable));
+    OWL_CUDA_CALL(GetDeviceCount(&totalNumDevicesAvailable));
     if (totalNumDevicesAvailable == 0)
       OWL_RAISE("#owl: no CUDA capable devices found!");
     LOG_OK("found " << totalNumDevicesAvailable << " CUDA device(s)");
@@ -201,8 +201,8 @@ namespace owl {
     
     LOG(" - device: " << getDeviceName());
     
-    CUDA_CHECK(cudaSetDevice(cudaDeviceID));
-    CUDA_CHECK(cudaStreamCreate(&stream));
+    OWL_CUDA_CHECK(cudaSetDevice(cudaDeviceID));
+    OWL_CUDA_CHECK(cudaStreamCreate(&stream));
     
     CUresult  cuRes = cuCtxGetCurrent(&cudaContext);
     if (cuRes != CUDA_SUCCESS) 

--- a/owl/DeviceContext.h
+++ b/owl/DeviceContext.h
@@ -142,17 +142,17 @@ namespace owl {
   struct SetActiveGPU {
     inline SetActiveGPU(const DeviceContext::SP &device)
     {
-      CUDA_CHECK(cudaGetDevice(&savedActiveDeviceID));
-      CUDA_CHECK(cudaSetDevice(device->cudaDeviceID));
+      OWL_CUDA_CHECK(cudaGetDevice(&savedActiveDeviceID));
+      OWL_CUDA_CHECK(cudaSetDevice(device->cudaDeviceID));
     }
     inline SetActiveGPU(const DeviceContext *device)
     {
-      CUDA_CHECK(cudaGetDevice(&savedActiveDeviceID));
-      CUDA_CHECK(cudaSetDevice(device->cudaDeviceID));
+      OWL_CUDA_CHECK(cudaGetDevice(&savedActiveDeviceID));
+      OWL_CUDA_CHECK(cudaSetDevice(device->cudaDeviceID));
     }
     inline ~SetActiveGPU()
     {
-      CUDA_CHECK_NOTHROW(cudaSetDevice(savedActiveDeviceID));
+      OWL_CUDA_CHECK_NOTHROW(cudaSetDevice(savedActiveDeviceID));
     }
   private:
     int savedActiveDeviceID = -1;

--- a/owl/DeviceMemory.h
+++ b/owl/DeviceMemory.h
@@ -47,7 +47,7 @@ namespace owl {
       
     assert(empty());
     this->sizeInBytes = size;
-    CUDA_CHECK(cudaMalloc( (void**)&d_pointer, sizeInBytes));
+    OWL_CUDA_CHECK(cudaMalloc( (void**)&d_pointer, sizeInBytes));
     assert(alloced() || size == 0);
   }
     
@@ -55,7 +55,7 @@ namespace owl {
   {
     assert(empty());
     this->sizeInBytes = size;
-    CUDA_CHECK(cudaMallocManaged( (void**)&d_pointer, sizeInBytes));
+    OWL_CUDA_CHECK(cudaMallocManaged( (void**)&d_pointer, sizeInBytes));
     assert(alloced() || size == 0);
   }
     
@@ -67,7 +67,7 @@ namespace owl {
   inline void DeviceMemory::upload(const void *h_pointer, const char *debugMessage)
   {
     assert(alloced() || empty());
-    CUDA_CHECK2(debugMessage,
+    OWL_CUDA_CHECK2(debugMessage,
                 cudaMemcpy((void*)d_pointer, h_pointer,
                            sizeInBytes, cudaMemcpyHostToDevice));
   }
@@ -75,7 +75,7 @@ namespace owl {
   inline void DeviceMemory::uploadAsync(const void *h_pointer, cudaStream_t stream)
   {
     assert(alloced() || empty());
-    CUDA_CHECK(cudaMemcpyAsync((void*)d_pointer, h_pointer,
+    OWL_CUDA_CHECK(cudaMemcpyAsync((void*)d_pointer, h_pointer,
                                sizeInBytes, cudaMemcpyHostToDevice,
                                stream));
   }
@@ -83,7 +83,7 @@ namespace owl {
   inline void DeviceMemory::download(void *h_pointer)
   {
     assert(alloced() || sizeInBytes == 0);
-    CUDA_CHECK(cudaMemcpy(h_pointer, (void*)d_pointer, 
+    OWL_CUDA_CHECK(cudaMemcpy(h_pointer, (void*)d_pointer, 
                           sizeInBytes, cudaMemcpyDeviceToHost));
   }
     
@@ -91,7 +91,7 @@ namespace owl {
   {
     assert(alloced() || empty());
     if (!empty()) {
-      CUDA_CHECK(cudaFree((void*)d_pointer));
+      OWL_CUDA_CHECK(cudaFree((void*)d_pointer));
     }
     sizeInBytes = 0;
     d_pointer   = 0;

--- a/owl/InstanceGroup.cpp
+++ b/owl/InstanceGroup.cpp
@@ -284,7 +284,7 @@ namespace owl {
                                 nullptr,0u
                                 ));
       
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     
     // ==================================================================
     // aaaaaand .... clean up
@@ -519,7 +519,7 @@ namespace owl {
                                 nullptr,0u
                                 ));
 
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     
     // ==================================================================
     // aaaaaand .... clean up

--- a/owl/LaunchParams.cpp
+++ b/owl/LaunchParams.cpp
@@ -43,7 +43,7 @@ namespace owl {
   {
     SetActiveGPU forLifeTime(device);
     
-    CUDA_CHECK(cudaStreamCreate(&stream));
+    OWL_CUDA_CHECK(cudaStreamCreate(&stream));
     deviceMemory.alloc(dataSize);
     hostMemory.resize(dataSize);
   }

--- a/owl/Texture.cpp
+++ b/owl/Texture.cpp
@@ -83,12 +83,12 @@ namespace owl {
       }        
 
       cudaArray_t   pixelArray;
-      CUDA_CALL(MallocArray(&pixelArray,
+      OWL_CUDA_CALL(MallocArray(&pixelArray,
                              &channel_desc,
                              size.x,size.y));
       textureArrays.push_back(pixelArray);
       
-      CUDA_CALL(Memcpy2DToArray(pixelArray,
+      OWL_CUDA_CALL(Memcpy2DToArray(pixelArray,
                                  /* offset */0,0,
                                  texels,
                                  pitch,pitch,size.y,
@@ -131,7 +131,7 @@ namespace owl {
       
       // Create texture object
       cudaTextureObject_t cuda_tex = 0;
-      CUDA_CALL(CreateTextureObject(&cuda_tex, &res_desc, &tex_desc, nullptr));
+      OWL_CUDA_CALL(CreateTextureObject(&cuda_tex, &res_desc, &tex_desc, nullptr));
 
       textureObjects.push_back(cuda_tex);
     }

--- a/owl/Triangles.cu
+++ b/owl/Triangles.cu
@@ -127,10 +127,10 @@ namespace owl {
         (((box3f*)d_bounds.get())+1,
          vertex.buffers[1]->getPointer(device),
          vertex.count,vertex.stride,vertex.offset);
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     d_bounds.download(&bounds[0]);
     d_bounds.free();
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     if (vertex.buffers.size() == 1)
       bounds[1] = bounds[0];
   }

--- a/owl/TrianglesGeomGroup.cpp
+++ b/owl/TrianglesGeomGroup.cpp
@@ -281,7 +281,7 @@ namespace owl {
                                   nullptr,0
                                   ));
     }
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     
     // ==================================================================
     // perform compaction
@@ -305,7 +305,7 @@ namespace owl {
       dd.memPeak += dd.bvhMemory.size();
       dd.memFinal = dd.bvhMemory.size();
     }
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
       
     // ==================================================================
     // aaaaaand .... clean up

--- a/owl/UserGeom.cu
+++ b/owl/UserGeom.cu
@@ -121,10 +121,10 @@ namespace owl {
       (((box3f*)d_bounds.get())+0,
        (box3f *)dd.internalBufferForBoundsProgram.get(),
        primCount);
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     d_bounds.download(&bounds[0]);
     d_bounds.free();
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
     bounds[1] = bounds[0];
   }
 

--- a/owl/UserGeomGroup.cpp
+++ b/owl/UserGeomGroup.cpp
@@ -232,7 +232,7 @@ namespace owl {
                                 nullptr,0u
                                 ));
       
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
 
     // ==================================================================
     // finish - clean up
@@ -257,7 +257,7 @@ namespace owl {
     if (FULL_REBUILD)
       dd.memPeak += sumBoundsMem;
 
-    CUDA_SYNC_CHECK();
+    OWL_CUDA_SYNC_CHECK();
   }
     
 } // ::owl

--- a/owl/helper/cuda.h
+++ b/owl/helper/cuda.h
@@ -19,7 +19,7 @@
 #include "owl/common.h"
 #include <cuda_runtime.h>
 
-#define CUDA_CHECK( call )                                              \
+#define OWL_CUDA_CHECK( call )                                              \
   {                                                                     \
     cudaError_t rc = call;                                              \
     if (rc != cudaSuccess) {                                            \
@@ -30,9 +30,9 @@
     }                                                                   \
   }
 
-#define CUDA_CALL(call) CUDA_CHECK(cuda##call)
+#define OWL_CUDA_CALL(call) OWL_CUDA_CHECK(cuda##call)
 
-#define CUDA_CHECK2( where, call )                                      \
+#define OWL_CUDA_CHECK2( where, call )                                      \
   {                                                                     \
     cudaError_t rc = call;                                              \
     if(rc != cudaSuccess) {                                             \
@@ -47,7 +47,7 @@
     }                                                                   \
   }
 
-#define CUDA_SYNC_CHECK()                                       \
+#define OWL_CUDA_SYNC_CHECK()                                       \
   {                                                             \
     cudaDeviceSynchronize();                                    \
     cudaError_t rc = cudaGetLastError();                        \
@@ -60,7 +60,7 @@
 
 
 
-#define CUDA_CHECK_NOTHROW( call )                                      \
+#define OWL_CUDA_CHECK_NOTHROW( call )                                      \
   {                                                                     \
     cudaError_t rc = call;                                              \
     if (rc != cudaSuccess) {                                            \
@@ -71,9 +71,9 @@
     }                                                                   \
   }
 
-#define CUDA_CALL_NOTHROW(call) CUDA_CHECK_NOTHROW(cuda##call)
+#define OWL_CUDA_CALL_NOTHROW(call) OWL_CUDA_CHECK_NOTHROW(cuda##call)
 
-#define CUDA_CHECK2_NOTHROW( where, call )                              \
+#define OWL_CUDA_CHECK2_NOTHROW( where, call )                              \
   {                                                                     \
     cudaError_t rc = call;                                              \
     if(rc != cudaSuccess) {                                             \


### PR DESCRIPTION
OWL currently exports CUDA_CALL, CUDA_SYNC, etc... macros, but these
are likely to name-clash with other external libraries that use the
same names.

This commit renames them to OWL_CUDA_CALL, OWL_CUDA_SYNC, etc... in
order to prevent such name-clashes to happen.

Fixes #141 