### PR TITLE
Fix wrong Sponza location as in #148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ Session.vim
 .idea
 !*png/*.pdf
 .vs/
+samples/advanced/optix7course/models/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(BUILD_SHARED_LIBS ${OWL_BUILD_SHARED}) # use 'OWL_' naming convention
 add_subdirectory(owl)
 
 option(OWL_BUILD_SAMPLES "Build the Samples?" ON)
+add_compile_definitions(OWL_BUILDING_ALL_SAMPLES)
 option(OWL_BUILD_ADVANCED_TESTS "Build the *advanced* test-cases?" OFF)
 
 add_subdirectory(3rdParty)

--- a/samples/advanced/optix7course/main.cpp
+++ b/samples/advanced/optix7course/main.cpp
@@ -101,6 +101,8 @@ namespace osc {
     std::string inFileName = 
 #ifdef _WIN32
 #ifdef OWL_BUILDING_ALL_SAMPLES
+      // on windows, when building the whole project (including the
+      // samples) with VS, the executable's location is different
       "../../samples/advanced/optix7course/models/sponza.obj"
 #else
       // on windows, visual studio creates _two_ levels of build dir

--- a/samples/advanced/optix7course/main.cpp
+++ b/samples/advanced/optix7course/main.cpp
@@ -100,9 +100,13 @@ namespace osc {
   {
     std::string inFileName = 
 #ifdef _WIN32
+#ifdef OWL_BUILDING_ALL_SAMPLES
+      "../../samples/advanced/optix7course/models/sponza.obj"
+#else
       // on windows, visual studio creates _two_ levels of build dir
       // (x86/Release)
       "../../models/sponza.obj"
+#endif
 #else
       // on linux, common practice is to have ONE level of build dir
       // (say, <project>/build/)...


### PR DESCRIPTION
As of now, when building the entirety of the OWL repo (including the
samples) under Windows with VS, the executable is not generated under
the same directory of the sample, but all executables end up in the
same directory (e.g. `build/Debug`).

As a result, the hardcoded path that the `samples/advanced/optix7course`
sample uses to find the Sponza model does not work. This commit
makes CMake set up a variable that signals whether the whole project
has been built, and in that case the sample looks for the appropriate
reative path for its location.

Fixes #148 