### PR TITLE
Fix include directories used to build libowl

### DIFF
--- a/owl/CMakeLists.txt
+++ b/owl/CMakeLists.txt
@@ -162,11 +162,10 @@ endif()
 
 target_include_directories(owl
   PUBLIC
-    /usr/local/cuda/include/
     ${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/include
 )
-set_property(TARGET owl PROPERTY CUDA_ARCHITECTURES OFF) 
+set_property(TARGET owl PROPERTY CUDA_ARCHITECTURES OFF)
 
 if (WIN32)
   target_compile_definitions(owl PUBLIC -DNOMINMAX)


### PR DESCRIPTION
This fixes issue #191

Remove include path /usr/local/cuda/include/ from the list of include directories used to build libowl.

On a system where several nvcc toolkit are installed, this path is often an alias to the latest installed toolkit; hence when trying to build with an older version off nvcc you end up in a situation where the old nvcc compiler is using new header; this situation may lead to error at link time (undefined symbols). See issue #191 for discussion.