### PR TITLE
adding some controls to override default number of ray payload registers

### DIFF
--- a/owl/Context.cpp
+++ b/owl/Context.cpp
@@ -596,6 +596,20 @@ namespace owl {
     } 
   }
 
+  void Context::setNumPayloadValues(size_t numPayloadValues)
+  {
+    if (numPayloadValues > 32)
+      OWL_RAISE
+        ("a payload count > 32 isnt' currently supported in OWL; "
+         "please see comments on owlSetNumPayloadValues() (owl/owl_host.h)");
+
+    for (auto device : getDevices()) {
+      assert("check programs have not been built"
+             && device->allActivePrograms.empty());
+    }
+    this->numPayloadValues = (int)numPayloadValues;
+  }
+
   void Context::enableMotionBlur()
   {
     motionBlurEnabled = true;

--- a/owl/Context.h
+++ b/owl/Context.h
@@ -116,6 +116,9 @@ namespace owl {
        to ClosestHit programs.  Default 2.  Has no effect once programs are built.*/
     void setNumAttributeValues(size_t numAttributeValues);
 
+    /* Set number of payload registers for passing data between raygen and raytracing 
+        programs.  Default 2.  Has no effect once programs are built.*/
+    void setNumPayloadValues(size_t numPayloadValues);
 
     // ------------------------------------------------------------------
     // internal mechanichs/plumbling that do the actual work
@@ -321,6 +324,9 @@ namespace owl {
 
     /* Number of attributes for writing data between Intersection and ClosestHit */
     int numAttributeValues = 2;
+
+    /* Number of payload registers for writing data between raygen and raytracing programs */
+    int numPayloadValues = 2;
 
     /*! a set of dummy (ie, empty) launch params. allows us for always
       using the same launch code, *with* launch params, even if th

--- a/owl/DeviceContext.cpp
+++ b/owl/DeviceContext.cpp
@@ -309,7 +309,7 @@ namespace owl {
       break;
     }
     pipelineCompileOptions.usesMotionBlur     = parent->motionBlurEnabled;
-    pipelineCompileOptions.numPayloadValues   = 2;
+    pipelineCompileOptions.numPayloadValues = parent->numPayloadValues;
     pipelineCompileOptions.numAttributeValues = parent->numAttributeValues;
     pipelineCompileOptions.exceptionFlags     = OPTIX_EXCEPTION_FLAG_NONE;
     pipelineCompileOptions.pipelineLaunchParamsVariableName = "optixLaunchParams";

--- a/owl/impl.cpp
+++ b/owl/impl.cpp
@@ -111,6 +111,13 @@ owlContextSetNumAttributeValues(OWLContext _context, size_t numAttributeValues)
 }
 
 OWL_API void
+owlContextSetNumPayloadValues(OWLContext _context, size_t numPayloadValues)
+{
+  LOG_API_CALL();
+  checkGet(_context)->setNumPayloadValues(numPayloadValues);
+}
+
+OWL_API void
 owlContextSetBoundLaunchParamValues(OWLContext _context,
                                     const OWLBoundValueDecl *_boundValues,
                                     int numBoundValues)

--- a/owl/include/owl/owl_host.h
+++ b/owl/include/owl/owl_host.h
@@ -401,6 +401,12 @@ OWL_API void
 owlContextSetNumAttributeValues(OWLContext context,
                                 size_t numAttributeValues);
 
+/* Set number of payload registers for passing data between raygen programs and 
+   closesthit / anyhit / miss programs.  Default 2.  Has no effect once programs are built.*/
+OWL_API void
+owlContextSetNumPayloadValues(OWLContext context,
+                                size_t numPayloadValues);
+
 /*! tells OptiX to specialize the values of certain launch parameters
   when compiling modules, and ignore their values at launch.
   See section 6.3.1 of the OptiX 7.2 programming guide.


### PR DESCRIPTION
This PR adds a "owlContextSetNumPayloadValues" function which allows users to override the default number of payload registers specified during pipeline creation.