### PR TITLE
Remove 'execinfo.h' include in owl-common.h - linux specific header

### DIFF
--- a/owl/include/owl/common/owl-common.h
+++ b/owl/include/owl/common/owl-common.h
@@ -30,7 +30,6 @@
 #include <math.h>
 #include <cmath>
 #include <algorithm>
-#include <execinfo.h>
 #include <sstream>
 #ifdef __GNUC__
 #include <execinfo.h>


### PR DESCRIPTION
Compilation on windows fails due to the following include in ```owl-common.h```
```
#include <cmath>
#include <algorithm>
#include <execinfo.h>   <-------- 
#include <sstream>
#ifdef __GNUC__
#include <execinfo.h>
#include <sys/time.h>
#endif
```

This header is already included below within required ```#ifdef```