### PR TITLE
fix UserTypeVariable internal data type

### DIFF
--- a/owl/Variable.cpp
+++ b/owl/Variable.cpp
@@ -194,7 +194,7 @@ namespace owl {
     }
     
     std::vector<std::vector<uint8_t>> dataPerDev;
-    std::vector<std::vector<uint8_t>> dataShared;
+    std::vector<uint8_t> dataShared;
   };
 
   /*! Variable type for basic and compound-basic data types such as


### PR DESCRIPTION
Fixes internal container type of dataShared member variable. Otherwise, it leads to a crash while cleaning up user-type variables, for example by calling owlContextDestroy.