### PR TITLE
Include Samples in Subprojects only if OWL_BUILD_SAMPLES is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,11 @@ add_subdirectory(3rdParty)
 # tutorial/samples
 # ------------------------------------------------------------------
 if (OWL_BUILD_SAMPLES)
-  add_subdirectory(samples)
-else()
-  add_subdirectory(samples EXCLUDE_FROM_ALL)
+	if(NOT OWL_IS_SUBPROJECT)
+		add_subdirectory(samples)
+	else()
+		add_subdirectory(samples EXCLUDE_FROM_ALL)
+	endif()
 endif()
 
 if (OWL_IS_SUBPROJECT)


### PR DESCRIPTION
Allows the user of owl to exclude the samples.

With 3f805af you forced cmake to add the samples as targets even if OWL_BUILD_SAMPLES is OFF . We're using Visual Studio and our cmake view gets cluttered with all those targets.

With this change the samples are not added, when owl is a subproject. If one would like to get the samples OWL_BUILD_SAMPLES must be set beforehand.

### Examples tested with Windows and VS.

We don't want the samples but the owl viewer:
```CMAKE
find_package(glfw3 CONFIG REQUIRED)
set(owl_dir ${CMAKE_CURRENT_LIST_DIR}/owl)
add_subdirectory(${owl_dir} EXCLUDE_FROM_ALL)
add_subdirectory(${owl_dir}/samples/common)
```

If one would like to add the samples when owl is a subproject:
```CMAKE
set(owl_dir ${CMAKE_CURRENT_LIST_DIR}/owl)
option(OWL_BUILD_SAMPLES ON)
add_subdirectory(${owl_dir} EXCLUDE_FROM_ALL)
```
